### PR TITLE
Add static create method for quick inlining calls

### DIFF
--- a/src/Cocur/Slugify/Slugify.php
+++ b/src/Cocur/Slugify/Slugify.php
@@ -138,6 +138,10 @@ class Slugify {
         }
     }
 
+    public static function create($mode = null) {
+        return new static($mode);
+    }
+
     /**
      * Takes a string and returns a slugified version of it. Slugs only consists of characters, numbers and the dash. They can be used in URLs.
      * @param  string $string     String


### PR DESCRIPTION
This allows 
`Slugify::create($mode)->slugify($string)` vs

```
$slugify = new Slugify($mode);
$slugify->slugify($string);
```

What do you think?
