### PR TITLE
Fixed minor spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage
 -----
 
 	<?php
-	use Cocur\Slugify\Slugiy;
+	use Cocur\Slugify\Slugify;
 
 	$slugify = new Slugify();//for iconv translit
     //$slugify = new Slugify(Slugify::MODEARRAY);//for array map


### PR DESCRIPTION
Fixed a minor spelling error error to save some time for other people that also copy and pastes namespaces to be sure it's right.
