### PR TITLE
add service alias for slugify

### DIFF
--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -43,5 +43,6 @@ class CocurSlugifyExtension extends Extension
                 array(new Reference('cocur_slugify'))
             )
         )->addTag('twig.extension');
+        $container->setAlias('slugify', 'cocur_slugify');
     }
 }

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -52,6 +52,10 @@ class CocurSlugifyExtensionTest extends \PHPUnit_Framework_TestCase
             ->with('cocur_slugify.twig.slugify', m::type('Symfony\Component\DependencyInjection\Definition'))
             ->once()
             ->andReturn($twigDefinition);
+        $container
+            ->shouldReceive('setAlias')
+            ->with('slugify', 'cocur_slugify')
+            ->once();
 
         $this->extension->load(array(), $container);
     }


### PR DESCRIPTION
In the docs, it says you can access the slugify service via:

``` php
$slug = $this->get('slugify')->slugify('Hello World!');
```

This does not work currently - you need to use:

``` php
$slug = $this->get('cocur_slugify')->slugify('Hello World!');
```

This PR adds a `slugify` service alias to allow the code in the docs to work.
