### PR TITLE
change in Czech slug of D/d with caron

### DIFF
--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -306,7 +306,7 @@ class Slugify implements SlugifyInterface
 
         // Czech
         'Č' => 'C',
-        'Ď' => 'Dj',
+        'Ď' => 'D',
         'Ě' => 'E',
         'Ň' => 'N',
         'Ř' => 'R',


### PR DESCRIPTION
"Ď" should be slugified as "D", not "Dj". Also coherent with python's slugify.
