### PR TITLE
[proposal] added SlugMap

### DIFF
--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -460,6 +460,11 @@ class Slugify implements SlugifyInterface
     );
 
     /**
+     * @var string[]|null
+     */
+    private $slugMap;
+
+    /**
      * Returns the slug-version of the string.
      *
      * @param string $string    String to slugify
@@ -469,6 +474,12 @@ class Slugify implements SlugifyInterface
      */
     public function slugify($string, $separator = '-')
     {
+        if($this->slugMap){
+            if(isset($this->slugMap[$string])){
+                return $this->slugMap[$string];
+            }
+        }
+
         $string = strtolower(strtr($string, $this->rules));
         $string = preg_replace('/([^a-z0-9]|-)+/', $separator, $string);
         $string = strtolower($string);
@@ -544,6 +555,35 @@ class Slugify implements SlugifyInterface
     public function getRulesets()
     {
         return $this->rulesets;
+    }
+
+    /**
+     * set a custom map for slugs
+     *
+     * @param array $slugMap
+     */
+    public function setSlugMap(array $slugMap){
+        $this->slugMap = $slugMap;
+    }
+
+    /**
+     * add a single slug to the slug map
+     *
+     * @param $string
+     * @param $slug
+     */
+    public function addSlugToMap($string, $slug){
+        $this->slugMap[$string] = $slug;
+    }
+
+    /**
+     * returns the slug map
+     *
+     * @return null|string[][] SlugMap
+     */
+    public function getSlugMap()
+    {
+        return $this->slugMap;
     }
 
     /**

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -110,6 +110,25 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Cocur\\Slugify\\SlugifyInterface', Slugify::create());
     }
 
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::setSlugMap()
+     * @covers Cocur\Slugify\Slugify::getSlugMap()
+     * @covers Cocur\Slugify\Slugify::addSlugToMap()
+     */
+    public function testSetSlugMap(){
+        $this->slugify->setSlugMap(array('Hello World' => 'hello-world',
+                                          "Mijn foto's" => 'mijn-fotos'));
+
+        $this->assertEquals('hello-world', $this->slugify->slugify('Hello World'));
+        $this->assertEquals('mijn-fotos', $this->slugify->slugify("Mijn foto's"));
+        $this->assertEquals('jouw-foto-s', $this->slugify->slugify("Jouw foto's"));
+        $this->assertCount(2, $this->slugify->getSlugMap());
+
+        $this->slugify->addSlugToMap("Jouw foto's", 'jouw-fotos');
+        $this->assertEquals('jouw-fotos', $this->slugify->slugify("Jouw foto's"));
+    }
+
     public function provider()
     {
         return array(


### PR DESCRIPTION
I introduced a slugMap to Slugify, which is checked before the actual strtr replacement, if set.

The slugMap can contain full strings instead of single chars as in ruleMaps. 

The main use case was Performance: in pages that have lots of slugify occurences, for whatever reason, one could fill the map from a cache instance, which is probably faster than to run strtr a hundred times. I had evidence here while profiling, but need to prove this with a benchmark, though.

I used to do this in a SlugifyProxy class, but maybe this is generic enough.
