### PR TITLE
Ease extension of Slugify class

### DIFF
--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -24,7 +24,7 @@ namespace Cocur\Slugify;
 class Slugify implements SlugifyInterface
 {
     /** @var array */
-    private $rules = array(
+    protected $rules = array(
         // Numeric characters
         '¹' => 1,
         '²' => 2,
@@ -442,7 +442,7 @@ class Slugify implements SlugifyInterface
     );
 
     /** @var string[][] */
-    private $rulesets = array(
+    protected $rulesets = array(
         'esperanto' => array(
             'ĉ' => 'cx',
             'ĝ' => 'gx',


### PR DESCRIPTION
I made a few minor changes.

Changed the visibility of rules and rulesets properties to protected to allow them to be overriden or used in child classes while extending Slugify.
Maybe using a getter for the rules property would do the same job, but this was my approach.

Added a third optional param to the `slufigy` method with the regular expression to be applied to the string.
I made this because I needed to allow other characters in the slug, like dots for filenames. I didn't want `My Cool File.zip` to become `my-cool-file-zip` but `my-cool-file.zip`.
I wasn't sure if that argument should be set in the constructor or in this method, but I think this is good enough.

I was thinking also on giving the option to define if the string should be lowered or not, but I'm not sure what's the best way to do that.
