### PR TITLE
Removing version from composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ Installation
 You can install cocur/slugify through [Composer](https://getcomposer.org):
 
 ```shell
-$ composer require cocur/slugify:@stable
+$ composer require cocur/slugify
 ```
-
-*In a production environment you should replace `@stable` with the [version](https://github.com/cocur/slugify/releases)
-you want to use.*
-
 
 Usage
 -----


### PR DESCRIPTION
Hi there!

If you omit the version, Composer selects the latest version for you. So, it's as easy as the old command, but puts a nice version in your composer.json instead of the `@stable`.

Thanks!
