### PR TITLE
Added 2 sentences which test polish diacritics

### DIFF
--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -165,7 +165,9 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
             array('Één jaar', 'een-jaar'),
             array('tiếng việt rất khó', 'tieng-viet-rat-kho'),
             array('Nguyễn Đăng Khoa', 'nguyen-dang-khoa'),
-            array('နှစ်သစ်ကူးတွင် သတ္တဝါတွေ စိတ်ချမ်းသာ ကိုယ်ကျန်းမာ၍ ကောင်းခြင်း အနန္တနှင့် ပြည့်စုံကြပါစေ', 'nhitthitkutwin-thttwatwe-seikkhyaantha-koekyaanmaywae-kaungkhyin-anntnhin-pyisonkypase')
+            array('နှစ်သစ်ကူးတွင် သတ္တဝါတွေ စိတ်ချမ်းသာ ကိုယ်ကျန်းမာ၍ ကောင်းခြင်း အနန္တနှင့် ပြည့်စုံကြပါစေ', 'nhitthitkutwin-thttwatwe-seikkhyaantha-koekyaanmaywae-kaungkhyin-anntnhin-pyisonkypase'),
+            array('Zażółć żółcią gęślą jaźń', 'zazolc-zolcia-gesla-jazn'),
+            array('Mężny bądź chroń pułk twój i sześć flag', 'mezny-badz-chron-pulk-twoj-i-szesc-flag')
         );
     }
 }


### PR DESCRIPTION
This PR contains two (true meaning) sentences which are used by polish developers to validate the text data.
First sentence contains all diacritics polish letters. The second one is a sentence which uses all letters from polish alphabet.

Wish you all best and thank you for good stuff.