### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,25 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+
+matrix:
+  allow_failures:
+    - php: 7.0
+  fast_finish: true
 
 addons:
   code_climate:
     repo_token: e27c69a17c19e62d55c1ec43eecc6821b905c504e5cb5cc4ad7f8a997163447a
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar --prefer-source --dev install
-  - cp phpunit.xml.dist phpunit.xml
+  - composer self-update
+  - composer install --prefer-source
 
 script:
   - mkdir -p build/logs
-  - ./vendor/bin/phpunit -c ./
+  - ./vendor/bin/phpunit
 
 after_script:
   - php vendor/bin/coveralls -v


### PR DESCRIPTION
- Travis has own composer, `self-update` suits better for this situation
- `--dev` is by default for couple of months
- `phpunit.xml.dist` is read by PHPUnit by default (if `phpunit.xml` not found)