### PR TITLE
Add more tests for long unicode strings

### DIFF
--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -213,7 +213,9 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
             array('Zażółć żółcią gęślą jaźń', 'zazolc-zolcia-gesla-jazn'),
             array('Mężny bądź chroń pułk twój i sześć flag', 'mezny-badz-chron-pulk-twoj-i-szesc-flag'),
             array('ერთი ორი სამი ოთხი ხუთი', 'erti-ori-sami-otkhi-khuti'),
-            array(str_repeat('Übergrößenträger', 1000), str_repeat('uebergroessentraeger', 1000))
+            array(str_repeat('Übergrößenträger', 1000), str_repeat('uebergroessentraeger', 1000)),
+            array(str_repeat('my🎉', 5000), substr(str_repeat('my-', 5000), 0, -1)),
+            array(str_repeat('hi🇦🇹', 5000), substr(str_repeat('hi-', 5000), 0, -1)),
         );
     }
 }


### PR DESCRIPTION
These tests use Emojis that are not transliterated by Slugify