### PR TITLE
Use singleton instead of bindShared

### DIFF
--- a/src/Bridge/Laravel/SlugifyServiceProvider.php
+++ b/src/Bridge/Laravel/SlugifyServiceProvider.php
@@ -40,7 +40,7 @@ class SlugifyServiceProvider extends LaravelServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('slugify', function () {
+        $this->app->singleton('slugify', function () {
             return new Slugify();
         });
     }


### PR DESCRIPTION
bindShared is deprecated (https://github.com/laravel/framework/blob/5.1/src/Illuminate/Container/Container.php#L289) and removed in Laravel 5.2