### PR TITLE
[SYMFONY] Add ability to configure slugify

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ The bundle also provides an alias `slugify` for the `cocur_slugify` service:
 $slug = $this->get('slugify')->slugify('Hello World!');
 ```
 
+You can set the following configuration settings in `app/config.yml` to adjust the slugify service:
+
+```yaml
+cocur_slugify:
+    lowercase: <boolean>
+    regexp: <string>
+    rulesets: { }
+```
+
 ### Twig
 
 If you use the Symfony2 framework with Twig you can use the Twig filter `slugify` in your templates after you have setup

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "mikey179/vfsStream":                   "~1.6",
         "symfony/http-kernel":                  "~2.4|~3.0",
         "symfony/dependency-injection":         "~2.4|~3.0",
+        "symfony/config":                       "~2.4|~3.0",
         "twig/twig":                            "~1.12",
         "silex/silex":                          "~1.3",
         "pimple/pimple":                        "~1.1",

--- a/src/Bridge/Symfony/CocurSlugifyBundle.php
+++ b/src/Bridge/Symfony/CocurSlugifyBundle.php
@@ -11,7 +11,6 @@
 
 namespace Cocur\Slugify\Bridge\Symfony;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -25,16 +24,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class CocurSlugifyBundle extends Bundle
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function build(ContainerBuilder $container)
+    public function getContainerExtension()
     {
-        parent::build($container);
-
-        $extension = new CocurSlugifyExtension();
-        $extension->load(array(), $container);
-
-        $container->registerExtension($extension);
+        return new CocurSlugifyExtension();
     }
 }

--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -35,7 +35,13 @@ class CocurSlugifyExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $container->setDefinition('cocur_slugify', new Definition('Cocur\Slugify\Slugify'));
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        // Extract slugify arguments from config
+        $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'regexp', 'rulesets']));
+
+        $container->setDefinition('cocur_slugify', new Definition('Cocur\Slugify\Slugify', [$slugifyArguments]));
         $container
             ->setDefinition(
                 'cocur_slugify.twig.slugify',

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the cocur/slugify package.
+ *
+ * (c) Enrico Stahn <enrico.stahn@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cocur\Slugify\Bridge\Symfony;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('cocur_slugify');
+
+        $rootNode
+            ->children()
+                ->booleanNode('lowercase')->defaultTrue()->end()
+                ->scalarNode('regexp')->end()
+                ->arrayNode('rulesets')->prototype('scalar')->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
@@ -26,26 +26,14 @@ use Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle;
  */
 class CocurSlugifyBundleTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        $this->bundle = new CocurSlugifyBundle();
-    }
-
     /**
-     * @test
-     * @covers Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle::build()
+     * @covers Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle::getContainerExtension()
      */
-    public function build()
+    public function testGetContainerExtension()
     {
-        $container = $this->getMock(
-            'Symfony\Component\DependencyInjection\ContainerBuilder',
-            array('registerExtension')
-        );
-        $container->expects($this->once())
-            ->method('registerExtension')
-            ->with($this->isInstanceOf('Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension'));
+        $bundle = new CocurSlugifyBundle();
 
-        $this->bundle->build($container);
+        static::assertInstanceOf(CocurSlugifyExtension::class, $bundle->getContainerExtension());
     }
 }
 

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -9,11 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Bundle;
+namespace Cocur\Slugify\Bridge\Symfony;
 
-use Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension;
-use \Mockery as m;
-
+use Mockery as m;
 
 /**
  * CocurSlugifyExtensionTest

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the cocur/slugify package.
+ *
+ * (c) Enrico Stahn <enrico.stahn@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cocur\Slugify\Bridge\Symfony;
+
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAll()
+    {
+        $configs = array(
+            array(
+                'lowercase' => true,
+                'regexp' => 'abcd',
+                'rulesets' => ['burmese', 'hindi']
+            ),
+        );
+
+        $this->process($configs);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     */
+    public function testLowercaseOnlyAcceptsBoolean()
+    {
+        $configs = [['lowercase' => 'abc']];
+        $this->process($configs);
+    }
+
+    /**
+     * Processes an array of configurations and returns a compiled version.
+     *
+     * @param array $configs An array of raw configurations
+     *
+     * @return array A normalized array
+     */
+    protected function process($configs)
+    {
+        $processor = new Processor();
+
+        return $processor->processConfiguration(new Configuration(), $configs);
+    }
+}


### PR DESCRIPTION
* Moved the `CocurSlugifyExtension` into the `DependencyInjection` folder to comply with Symfony's bundle standard
* Added configuration for the slugify service (e.g. enable lowercase)