### PR TITLE
Add option to specify default separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ $slugify = new Slugify(['lowercase' => false]);
 $slugify->slugify('Hello World'); // -> "Hello-World"
 ```
 
+By default Slugify will use dashes as separators. If you want to use a different default separator, you can set the
+`separator` option.
+
+```php
+$slugify = new Slugify(['separator' => '_']);
+$slugify->slugify('Hello World'); // -> "hello_world"
+```
+
 ### Contributing
 
 Feel free to ask for new rules for languages that is not already here.
@@ -177,6 +185,7 @@ You can set the following configuration settings in `app/config.yml` to adjust t
 ```yaml
 cocur_slugify:
     lowercase: <boolean>
+    separator: <string>
     regexp: <string>
     rulesets: { }
 ```
@@ -255,7 +264,7 @@ use Cocur\Slugify\Slugify;
 
 $mustache = new Mustache_Engine(array(
     // ...
-    'helpers' => array('slugify' => function($string, $separator = '-') {
+    'helpers' => array('slugify' => function($string, $separator = null) {
         return Slugify::create()->slugify($string, $separator);
     }),
 ));

--- a/src/Bridge/Latte/SlugifyHelper.php
+++ b/src/Bridge/Latte/SlugifyHelper.php
@@ -26,12 +26,12 @@ class SlugifyHelper
     }
 
     /**
-     * @param string $string
-     * @param string $separator
+     * @param string      $string
+     * @param string|null $separator
      *
      * @return string
      */
-    public function slugify($string, $separator = '-')
+    public function slugify($string, $separator = null)
     {
         return $this->slugify->slugify($string, $separator);
     }

--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -39,7 +39,7 @@ class CocurSlugifyExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         // Extract slugify arguments from config
-        $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'regexp', 'rulesets']));
+        $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'separator', 'regexp', 'rulesets']));
 
         $container->setDefinition('cocur_slugify', new Definition('Cocur\Slugify\Slugify', [$slugifyArguments]));
         $container

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('lowercase')->defaultTrue()->end()
+                ->scalarNode('separator')->defaultValue('-')->end()
                 ->scalarNode('regexp')->end()
                 ->arrayNode('rulesets')->prototype('scalar')->end()
             ->end();

--- a/src/Bridge/Twig/SlugifyExtension.php
+++ b/src/Bridge/Twig/SlugifyExtension.php
@@ -57,12 +57,12 @@ class SlugifyExtension extends \Twig_Extension
     /**
      * Slugify filter.
      *
-     * @param string $string
-     * @param string $separator
+     * @param string      $string
+     * @param string|null $separator
      *
      * @return string
      */
-    public function slugifyFilter($string, $separator = '-')
+    public function slugifyFilter($string, $separator = null)
     {
         return $this->slugify->slugify($string, $separator);
     }

--- a/src/Bridge/ZF2/SlugifyViewHelper.php
+++ b/src/Bridge/ZF2/SlugifyViewHelper.php
@@ -29,12 +29,12 @@ class SlugifyViewHelper extends AbstractHelper
     }
 
     /**
-     * @param string $string
-     * @param string $separator
+     * @param string      $string
+     * @param string|null $separator
      *
      * @return string
      */
-    public function __invoke($string, $separator = '-')
+    public function __invoke($string, $separator = null)
     {
         return $this->slugify->slugify($string, $separator);
     }

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -43,6 +43,7 @@ class Slugify implements SlugifyInterface
      */
     protected $options = [
         'regexp'    => self::LOWERCASE_NUMBERS_DASHES,
+        'separator' => '-',
         'lowercase' => true,
         'rulesets'  => [
             'default',
@@ -84,16 +85,19 @@ class Slugify implements SlugifyInterface
     /**
      * Returns the slug-version of the string.
      *
-     * @param string $string    String to slugify
-     * @param string $separator Separator
+     * @param string      $string    String to slugify
+     * @param string|null $separator Separator
      *
      * @return string Slugified version of the string
      */
-    public function slugify($string, $separator = '-')
+    public function slugify($string, $separator = null)
     {
         $string = strtr($string, $this->rules);
         if ($this->options['lowercase']) {
             $string = mb_strtolower($string);
+        }
+        if ($separator === null) {
+            $separator = $this->options['separator'];
         }
         $string = preg_replace($this->options['regexp'], $separator, $string);
 

--- a/src/SlugifyInterface.php
+++ b/src/SlugifyInterface.php
@@ -25,12 +25,12 @@ interface SlugifyInterface
     /**
      * Return a URL safe version of a string.
      *
-     * @param string $string
-     * @param string $separator
+     * @param string      $string
+     * @param string|null $separator
      *
      * @return string
      *
      * @api
      */
-    public function slugify($string, $separator = '-');
+    public function slugify($string, $separator = null);
 }

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -20,6 +20,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $configs = array(
             array(
                 'lowercase' => true,
+                'separator' => '_',
                 'regexp' => 'abcd',
                 'rulesets' => ['burmese', 'hindi']
             ),

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -137,6 +137,34 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->slugify->slugify($actual));
     }
 
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::__construct()
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyDefaultsToSeparatorOption()
+    {
+        $actual   = 'file name';
+        $expected = 'file__name';
+
+        $this->slugify = new Slugify(['separator' => '__']);
+        $this->assertEquals($expected, $this->slugify->slugify($actual));
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::__construct()
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyHonorsSeparatorArgument()
+    {
+        $actual   = 'file name';
+        $expected = 'file__name';
+
+        $this->slugify = new Slugify(['separator' => 'dummy']);
+        $this->assertEquals($expected, $this->slugify->slugify($actual, '__'));
+    }
+
     public function defaultRuleProvider()
     {
         return [


### PR DESCRIPTION
In order to configure a `Slugify` instance through constructor options, I added an option to specify the default separator. This change is backwards-compatible.

This way, callers can just call `slugify()` with one argument and the custom separator is not repeated over and over again.