### PR TITLE
Fix: Namespace of test classes does not match project structure

### DIFF
--- a/tests/Bridge/Laravel/SlugifyProviderTest.php
+++ b/tests/Bridge/Laravel/SlugifyProviderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Laravel;
+namespace Cocur\Slugify\Tests\Bridge\Laravel;
 
 use Cocur\Slugify\Bridge\Laravel\SlugifyServiceProvider;
 use Illuminate\Foundation\Application;
@@ -26,7 +26,7 @@ use Illuminate\Foundation\Application;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SlugifyProviderTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Application */
     private $app;

--- a/tests/Bridge/Latte/SlugifyHelperTest.php
+++ b/tests/Bridge/Latte/SlugifyHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cocur\Slugify\Bridge\Latte;
+namespace Cocur\Slugify\Tests\Bridge\Latte;
 
 use Cocur\Slugify\Bridge\Latte\SlugifyHelper;
 use Mockery as m;

--- a/tests/Bridge/Nette/SlugifyExtensionTest.php
+++ b/tests/Bridge/Nette/SlugifyExtensionTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Cocur\Slugify\Bridge\Nette;
+namespace Cocur\Slugify\Tests\Bridge\Nette;
 
+use Cocur\Slugify\Bridge\Nette\SlugifyExtension;
 use Mockery as m;
 
 /**

--- a/tests/Bridge/Plum/SlugifyConverterTest.php
+++ b/tests/Bridge/Plum/SlugifyConverterTest.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Plum;
+namespace Cocur\Slugify\Tests\Bridge\Plum;
 
+use Cocur\Slugify\Bridge\Plum\SlugifyConverter;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 

--- a/tests/Bridge/Silex/SlugifySilexProviderTest.php
+++ b/tests/Bridge/Silex/SlugifySilexProviderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Silex;
+namespace Cocur\Slugify\Tests\Bridge\Silex;
 
 use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
 use Silex\Application;
@@ -26,7 +26,7 @@ use Silex\Provider\TwigServiceProvider;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SlugifySilexProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test

--- a/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
@@ -9,9 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Symfony;
+namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
 use Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle;
+use Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension;
 
 /**
  * CocurSlugifyBundleTest

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Symfony;
+namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
+use Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension;
 use Mockery as m;
 
 /**

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Symfony;
+namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
+use Cocur\Slugify\Bridge\Symfony\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\Bridge\Twig;
+namespace Cocur\Slugify\Tests\Bridge\Twig;
 
 use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
 use Mockery as m;

--- a/tests/Bridge/ZF2/ModuleTest.php
+++ b/tests/Bridge/ZF2/ModuleTest.php
@@ -1,5 +1,7 @@
 <?php
-namespace Cocur\Slugify\Bridge\ZF2;
+namespace Cocur\Slugify\Tests\Bridge\ZF2;
+
+use Cocur\Slugify\Bridge\ZF2\Module;
 
 /**
  * Class ModuleTest

--- a/tests/Bridge/ZF2/SlugifyServiceTest.php
+++ b/tests/Bridge/ZF2/SlugifyServiceTest.php
@@ -1,6 +1,8 @@
 <?php
-namespace Cocur\Slugify\Bridge\ZF2;
+namespace Cocur\Slugify\Tests\Bridge\ZF2;
 
+use Cocur\Slugify\Bridge\ZF2\Module;
+use Cocur\Slugify\Bridge\ZF2\SlugifyService;
 use Zend\ServiceManager\ServiceManager;
 
 /**

--- a/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace Cocur\Slugify\Bridge\ZF2;
+namespace Cocur\Slugify\Tests\Bridge\ZF2;
 
+use Cocur\Slugify\Bridge\ZF2\SlugifyViewHelperFactory;
 use Cocur\Slugify\Slugify;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;

--- a/tests/Bridge/ZF2/SlugifyViewHelperTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace Cocur\Slugify\Bridge\ZF2;
+namespace Cocur\Slugify\Tests\Bridge\ZF2;
 
+use Cocur\Slugify\Bridge\ZF2\SlugifyViewHelper;
 use Cocur\Slugify\Slugify;
 
 /**

--- a/tests/RuleProvider/FileRuleProviderTest.php
+++ b/tests/RuleProvider/FileRuleProviderTest.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Cocur\Slugify\RuleProvider;
+namespace Cocur\Slugify\Tests\RuleProvider;
 
+use Cocur\Slugify\RuleProvider\FileRuleProvider;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit_Framework_TestCase;
 


### PR DESCRIPTION
This PR

* [x] fixes the namespace of test classes to match the project structure, and consequently adds missing imports

💁 The namespace should be `Cocur\Slugify\Bridge\Tests`, right?!