### PR TITLE
Enhancement: Provide SlugifyServiceProvider for league/container

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,58 @@ In a template you can use it like this:
 <a href="/blog/{{ post.title|slugify }}">{{ post.title|raw }}</a></h5>
 ```
 
+### League
+
+Slugify provides a service provider for use with `league/container`:
+
+```php
+use Cocur\Slugify;
+use League\Container;
+
+/* @var Container\ContainerInterface $container */
+$container->addServiceProvider(new Slugify\Bridge\League\SlugifyServiceProvider());
+
+/* @var Slugify\Slugify $slugify */
+$slugify = $container->get(Slugify\SlugifyInterface::class);
+```
+
+You can configure it by sharing the required options:
+
+```php
+use Cocur\Slugify;
+use League\Container;
+
+/* @var Container\ContainerInterface $container */
+$container->share('config.slugify.options', [
+    'lowercase' => false,
+    'rulesets' => [
+        'default',
+        'german',
+    ],
+]);
+
+$container->addServiceProvider(new Slugify\Bridge\League\SlugifyServiceProvider());
+
+/* @var Slugify\Slugify $slugify */
+$slugify = $container->get(Slugify\SlugifyInterface::class);
+```
+
+You can configure which rule provider to use by sharing it:
+
+```php
+use Cocur\Slugify;
+use League\Container;
+
+/* @var Container\ContainerInterface $container */
+$container->share(Slugify\RuleProvider\RuleProviderInterface::class, function () {
+    return new Slugify\RuleProvider\FileRuleProvider(__DIR__ . '/../../rules');
+]);
+
+$container->addServiceProvider(new Slugify\Bridge\League\SlugifyServiceProvider());
+
+/* @var Slugify\Slugify $slugify */
+$slugify = $container->get(Slugify\SlugifyInterface::class);
+```
 
 Change Log
 ----------

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require-dev": {
         "laravel/framework": "~5.1",
         "latte/latte": "~2.2",
+        "league/container": "^2.2.0",
         "mikey179/vfsStream": "~1.6",
         "mockery/mockery": "~0.9",
         "nette/di": "~2.2",

--- a/src/Bridge/League/SlugifyServiceProvider.php
+++ b/src/Bridge/League/SlugifyServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Cocur\Slugify\Bridge\League;
+
+use Cocur\Slugify\RuleProvider\DefaultRuleProvider;
+use Cocur\Slugify\RuleProvider\RuleProviderInterface;
+use Cocur\Slugify\Slugify;
+use Cocur\Slugify\SlugifyInterface;
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+class SlugifyServiceProvider extends AbstractServiceProvider
+{
+    protected $provides = [
+        SlugifyInterface::class,
+    ];
+
+    public function register()
+    {
+        $this->container->share(SlugifyInterface::class, function () {
+            $options = [];
+            if ($this->container->has('config.slugify.options')) {
+                $options = $this->container->get('config.slugify.options');
+            }
+
+            $provider = null;
+            if ($this->container->has(RuleProviderInterface::class)) {
+                /* @var RuleProviderInterface $provider */
+                $provider = $this->container->get(RuleProviderInterface::class);
+            }
+
+            return new Slugify(
+                $options,
+                $provider
+            );
+        });
+    }
+}

--- a/tests/Bridge/League/SlugifyServiceProviderTest.php
+++ b/tests/Bridge/League/SlugifyServiceProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Cocur\Slugify\Tests\Bridge\League;
+
+use Cocur\Slugify\Bridge\League\SlugifyServiceProvider;
+use Cocur\Slugify\RuleProvider\DefaultRuleProvider;
+use Cocur\Slugify\RuleProvider\RuleProviderInterface;
+use Cocur\Slugify\SlugifyInterface;
+use League\Container\Container;
+use Mockery as m;
+
+class SlugifyServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProvidesSlugify()
+    {
+        $container = new Container();
+
+        $container->addServiceProvider(new SlugifyServiceProvider());
+
+        $slugify = $container->get(SlugifyInterface::class);
+
+        $this->assertInstanceOf(SlugifyInterface::class, $slugify);
+        $this->assertAttributeInstanceOf(DefaultRuleProvider::class, 'provider', $slugify);
+    }
+
+    public function testProvidesSlugifyAsSharedService()
+    {
+        $container = new Container();
+
+        $container->addServiceProvider(new SlugifyServiceProvider());
+
+        $slugify = $container->get(SlugifyInterface::class);
+
+        $this->assertSame($slugify, $container->get(SlugifyInterface::class));
+    }
+
+    public function testProvidesSlugifyUsingSharedConfigurationOptions()
+    {
+        $container = new Container();
+
+        $options = [
+            'lowercase' => false,
+        ];
+
+        $container->share('config.slugify.options', $options);
+        $container->addServiceProvider(new SlugifyServiceProvider());
+
+        /* @var SlugifyInterface $slugify */
+        $slugify = $container->get(SlugifyInterface::class);
+
+        $slug = 'Foo-Bar-Baz';
+
+        $this->assertSame($slug, $slugify->slugify($slug));
+    }
+
+    public function testProvidesSlugifyUsingSharedProvider()
+    {
+        $container = new Container();
+
+        $ruleProvider = $this->getRuleProviderMock();
+
+        $container->share(RuleProviderInterface::class, $ruleProvider);
+        $container->addServiceProvider(new SlugifyServiceProvider());
+
+        $slugify = $container->get(SlugifyInterface::class);
+
+        $this->assertAttributeSame($ruleProvider, 'provider', $slugify);
+    }
+
+    /**
+     * @return m\Mock|RuleProviderInterface
+     */
+    private function getRuleProviderMock()
+    {
+        $ruleProvider = m::mock(RuleProviderInterface::class);
+
+        $ruleProvider
+            ->shouldReceive('getRules')
+            ->withAnyArgs()
+            ->andReturn([])
+        ;
+
+        return $ruleProvider;
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires [`league/container`](https://github.com/thephpleague/container)
* [x] provides a `SlugifyServiceProvider` for use with `league/container`