### PR TITLE
Fix: Keep packages sorted alphabetically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,22 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
-        "phpunit/phpunit":                      "~4.8|~5.2",
-        "mockery/mockery":                      "~0.9",
-        "mikey179/vfsStream":                   "~1.6",
-        "symfony/http-kernel":                  "~2.4|~3.0",
-        "symfony/dependency-injection":         "~2.4|~3.0",
-        "symfony/config":                       "~2.4|~3.0",
-        "twig/twig":                            "~1.12",
-        "silex/silex":                          "~1.3",
-        "pimple/pimple":                        "~1.1",
-        "zendframework/zend-modulemanager":     "~2.2",
-        "zendframework/zend-view":              "~2.2",
-        "zendframework/zend-servicemanager":    "~2.2",
-        "laravel/framework":                    "~5.1",
-        "nette/di":                             "~2.2",
-        "latte/latte":                          "~2.2",
-        "plumphp/plum":                         "~0.1"
+        "laravel/framework": "~5.1",
+        "latte/latte": "~2.2",
+        "mikey179/vfsStream": "~1.6",
+        "mockery/mockery": "~0.9",
+        "nette/di": "~2.2",
+        "phpunit/phpunit": "~4.8|~5.2",
+        "pimple/pimple": "~1.1",
+        "plumphp/plum": "~0.1",
+        "silex/silex": "~1.3",
+        "symfony/config": "~2.4|~3.0",
+        "symfony/dependency-injection": "~2.4|~3.0",
+        "symfony/http-kernel": "~2.4|~3.0",
+        "twig/twig": "~1.12",
+        "zendframework/zend-modulemanager": "~2.2",
+        "zendframework/zend-servicemanager": "~2.2",
+        "zendframework/zend-view": "~2.2"
     },
     "autoload": {
         "psr-4": {"Cocur\\Slugify\\": "src"}


### PR DESCRIPTION
This PR

* [x] keeps packages sorted alphabetically

💁 Ran

```
$ composer require --dev --sort-packages plumphp/plum:~0.1
```

For reference, see https://getcomposer.org/doc/03-cli.md#require:

> **--sort-packages**: Keep packages sorted in `composer.json`.