### PR TITLE
Fix: No need to prepend \

### DIFF
--- a/tests/Bridge/Latte/SlugifyHelperTest.php
+++ b/tests/Bridge/Latte/SlugifyHelperTest.php
@@ -3,7 +3,7 @@
 namespace Cocur\Slugify\Bridge\Latte;
 
 use Cocur\Slugify\Bridge\Latte\SlugifyHelper;
-use \Mockery as m;
+use Mockery as m;
 
 /**
  * SlugifyHelperTest

--- a/tests/Bridge/Nette/SlugifyExtensionTest.php
+++ b/tests/Bridge/Nette/SlugifyExtensionTest.php
@@ -2,7 +2,7 @@
 
 namespace Cocur\Slugify\Bridge\Nette;
 
-use \Mockery as m;
+use Mockery as m;
 
 /**
  * SlugifyExtensionTest

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -12,7 +12,7 @@
 namespace Cocur\Slugify\Bridge\Twig;
 
 use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
-use \Mockery as m;
+use Mockery as m;
 
 
 /**


### PR DESCRIPTION
This PR

* [x] removes leading `\` when importing `Mockery`