### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/Bridge/Laravel/SlugifyProviderTest.php
+++ b/tests/Bridge/Laravel/SlugifyProviderTest.php
@@ -34,7 +34,7 @@ class SlugifyServiceProviderTest extends \PHPUnit_Framework_TestCase
     /** @var SlugifyServiceProvider */
     private $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->app = new Application();
         $this->provider = new SlugifyServiceProvider($this->app);

--- a/tests/Bridge/Latte/SlugifyHelperTest.php
+++ b/tests/Bridge/Latte/SlugifyHelperTest.php
@@ -17,7 +17,7 @@ use \Mockery as m;
  */
 class SlugifyHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->slugify = m::mock('Cocur\Slugify\SlugifyInterface');
         $this->helper = new SlugifyHelper($this->slugify);

--- a/tests/Bridge/Nette/SlugifyExtensionTest.php
+++ b/tests/Bridge/Nette/SlugifyExtensionTest.php
@@ -16,7 +16,7 @@ use \Mockery as m;
  */
 class SlugifyExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->extension = new SlugifyExtension();
     }

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -26,7 +26,7 @@ use Mockery as m;
  */
 class CocurSlugifyExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->extension = new CocurSlugifyExtension();
     }

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -38,7 +38,7 @@ class SlugifyExtensionTest extends \PHPUnit_Framework_TestCase
      */
     protected $extension;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->slugify = m::mock('Cocur\Slugify\SlugifyInterface');
         $this->extension = new SlugifyExtension($this->slugify);

--- a/tests/Bridge/ZF2/ModuleTest.php
+++ b/tests/Bridge/ZF2/ModuleTest.php
@@ -14,7 +14,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
      */
     private $module;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->module = new Module();
     }

--- a/tests/Bridge/ZF2/SlugifyServiceTest.php
+++ b/tests/Bridge/ZF2/SlugifyServiceTest.php
@@ -16,7 +16,7 @@ class SlugifyServiceTest extends \PHPUnit_Framework_TestCase
      */
     private $slugifyService;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->slugifyService = new SlugifyService();
     }

--- a/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
@@ -18,7 +18,7 @@ class SlugifyViewHelperFactoryTest extends \PHPUnit_Framework_TestCase
      */
     private $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = new SlugifyViewHelperFactory();
     }

--- a/tests/Bridge/ZF2/SlugifyViewHelperTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperTest.php
@@ -23,7 +23,7 @@ class SlugifyViewHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Cocur\Slugify\Bridge\ZF2\SlugifyViewHelper::__construct()
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->slugify = new Slugify();
         $this->viewHelper = new SlugifyViewHelper($this->slugify);

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -37,7 +37,7 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
      */
     private $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->provider = Mockery::mock('\Cocur\Slugify\RuleProvider\RuleProviderInterface');
         $this->provider->shouldReceive('getRules')->andReturn([]);


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`

💁 This is the visibility as declared on the [parent](https://github.com/sebastianbergmann/phpunit/blob/97212e797a47acab932df4c8d1cc1e3c18131fe9/src/Framework/TestCase.php#L2179-L2185), and there's no need to increase it, is there?