### PR TITLE
Fix: Attempt to cache dependencies installed with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
     - php: nightly
   fast_finish: true
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - travis_retry composer self-update && composer --version
 


### PR DESCRIPTION
This PR

* [x] attempts to cache dependencies as installed with composer between builds

💁 For reference, see https://docs.travis-ci.com/user/caching/#Arbitrary-directories.