### PR TITLE
Update silex 2 provider

### DIFF
--- a/src/Bridge/Silex2/SlugifyServiceProvider.php
+++ b/src/Bridge/Silex2/SlugifyServiceProvider.php
@@ -15,7 +15,6 @@ use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
 use Cocur\Slugify\Slugify;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Silex\Application;
 
 /**
  * SlugifyServiceProvider
@@ -39,18 +38,11 @@ class SlugifyServiceProvider implements ServiceProviderInterface
         };
 
         if (isset($container['twig'])) {
-            $container['twig'] = $container->extend('twig', function (\Twig_Environment $twig, $container) {
+            $container->extend('twig', function (\Twig_Environment $twig, $container) {
                 $twig->addExtension(new SlugifyExtension($container['slugify']));
 
                 return $twig;
             });
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function boot(Application $app)
-    {
     }
 }


### PR DESCRIPTION
Hello,

Here's a PR to update the silex2 provider with 2 points:
No need to affect the result of `$container->extend()` in Pimple 3.
The `->boot()` method is now part of the interface `Silex\Api\BootableProviderInterface` and useless in the implementation of `Pimple\ServiceProviderInterface`.

I have not been able to add tests for both version 1 & 2.
