### PR TITLE
Allow to modify options without creating a new object

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ $slugify = new Slugify();
 $slugify->slugify('Hello World', ['separator' => '_']); // -> "hello_world"
 ```
 
+You can even activate a custom ruleset without touching the default rules:
+
+```php
+$slugify = new Slugify();
+$slugify->slugify('für', ['ruleset' => 'turkish']); // -> "fur"
+$slugify->slugify('für'); // -> "fuer"
+```
+
 ### Contributing
 
 Feel free to ask for new rules for languages that is not already here.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ $slugify = new Slugify(['separator' => '_']);
 $slugify->slugify('Hello World'); // -> "hello_world"
 ```
 
+### Changing options on the fly
+
+You can overwrite any of the above options on the fly by passing an options array as second argument to the `slugify()`
+method. For example:
+
+```php
+$slugify = new Slugify();
+$slugify->slugify('Hello World', ['lowercase' => false]); // -> "Hello-World"
+```
+
+You can also modify the separator this way:
+
+```php
+$slugify = new Slugify();
+$slugify->slugify('Hello World', ['separator' => '_']); // -> "hello_world"
+```
+
 ### Contributing
 
 Feel free to ask for new rules for languages that is not already here.

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -95,8 +95,8 @@ class Slugify implements SlugifyInterface
     {
         // BC: the second argument used to be the separator
         if (is_string($options)) {
-            $separator = $options;
-            $options = [];
+            $separator            = $options;
+            $options              = [];
             $options['separator'] = $separator;
         }
 

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -101,7 +101,16 @@ class Slugify implements SlugifyInterface
         }
 
         $options = array_merge($this->options, (array) $options);
-        $string = strtr($string, $this->rules);
+
+        // Add a custom ruleset without touching the default rules
+        if (isset($options['ruleset'])) {
+            $rules = array_merge($this->rules, $this->provider->getRules($options['ruleset']));
+        } else {
+            $rules = $this->rules;
+        }
+
+        $string = strtr($string, $rules);
+        unset($rules);
 
         if ($options['lowercase']) {
             $string = mb_strtolower($string);

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -86,23 +86,30 @@ class Slugify implements SlugifyInterface
     /**
      * Returns the slug-version of the string.
      *
-     * @param string      $string    String to slugify
-     * @param string|null $separator Separator
+     * @param string            $string  String to slugify
+     * @param string|array|null $options Options
      *
      * @return string Slugified version of the string
      */
-    public function slugify($string, $separator = null)
+    public function slugify($string, $options = null)
     {
+        // BC: the second argument used to be the separator
+        if (is_string($options)) {
+            $separator = $options;
+            $options = [];
+            $options['separator'] = $separator;
+        }
+
+        $options = array_merge($this->options, (array) $options);
         $string = strtr($string, $this->rules);
-        if ($this->options['lowercase']) {
+
+        if ($options['lowercase']) {
             $string = mb_strtolower($string);
         }
-        if ($separator === null) {
-            $separator = $this->options['separator'];
-        }
-        $string = preg_replace($this->options['regexp'], $separator, $string);
 
-        return trim($string, $separator);
+        $string = preg_replace($options['regexp'], $options['separator'], $string);
+
+        return trim($string, $options['separator']);
     }
 
     /**

--- a/src/SlugifyInterface.php
+++ b/src/SlugifyInterface.php
@@ -25,12 +25,12 @@ interface SlugifyInterface
     /**
      * Return a URL safe version of a string.
      *
-     * @param string      $string
-     * @param string|null $separator
+     * @param string            $string
+     * @param string|array|null $options
      *
      * @return string
      *
      * @api
      */
-    public function slugify($string, $separator = null);
+    public function slugify($string, $options = null);
 }

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -202,6 +202,18 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FILE-NAME', $this->slugify->slugify('FILE NAME', ['lowercase' => false]));
     }
 
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyCustomRuleSet()
+    {
+        $slugify = new Slugify();
+
+        $this->assertSame('fur', $slugify->slugify('für', ['ruleset' => 'turkish']));
+        $this->assertSame('fuer', $slugify->slugify('für'));
+    }
+
     public function defaultRuleProvider()
     {
         return [

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -186,6 +186,22 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->slugify->slugify($actual, '__'));
     }
 
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyOptionsArray()
+    {
+        $this->assertEquals('file-name', $this->slugify->slugify('file name'));
+        $this->assertEquals('file+name', $this->slugify->slugify('file name', ['separator' => '+']));
+
+        $this->assertEquals('name-1', $this->slugify->slugify('name(1)'));
+        $this->assertEquals('name(1)', $this->slugify->slugify('name(1)', ['regexp' => '/([^a-z0-9.()]|-)+/']));
+
+        $this->assertEquals('file-name', $this->slugify->slugify('FILE NAME'));
+        $this->assertEquals('FILE-NAME', $this->slugify->slugify('FILE NAME', ['lowercase' => false]));
+    }
+
     public function defaultRuleProvider()
     {
         return [


### PR DESCRIPTION
Right now we need to create a new object instance every time we e.g. need a different regexp. This is cumbersome when using the library as a Symfony service, because it would require to define one service per configuration.

This PR adds methods to modify the options on the fly, so we can e.g. do this:

```php
$slugify = $container->get('slugify');
$slugify->slugify('MY STRING', ['lowercase' => false]); // MY-STRING
```

TODO

- [x] Add the unit tests

If you decide that you want to implement this, I'll happily add the unit tests.