### PR TITLE
Add support for Twig 2.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ removing these characters, Slugify approximates them (e.g., `ae` replaces `ä`).
 - PSR-4 compatible.
 - Compatible with PHP >= 5.5.9, PHP 7 and [HHVM](http://hhvm.com).
 - Integrations for [Symfony2](http://symfony.com), [Silex (1 and 2)](http://silex.sensiolabs.org), [Laravel](http://laravel.com),
-[Twig](http://twig.sensiolabs.org), [Zend Framework 2](http://framework.zend.com/), [Nette Framework](http://nette.org/), 
+[Twig (1 and 2)](http://twig.sensiolabs.org), [Zend Framework 2](http://framework.zend.com/), [Nette Framework](http://nette.org/),
 [Latte](http://latte.nette.org/) and [Plum](https://github.com/plumphp/plum).
 
 
@@ -95,7 +95,7 @@ You can find a list of the available rulesets in `Resources/rules`.
 
 ### More options
 
-The constructor takes an options array, you have already seen the `rulesets` options above. You can also change the 
+The constructor takes an options array, you have already seen the `rulesets` options above. You can also change the
 regular expression that is used to replace characters with the separator.
 
 ```php
@@ -654,7 +654,7 @@ inform us if a transliteration is wrong. We would highly appreciate it if you ca
 Github. If you have never contributed to a project on Github we are happy to help you. Just ask on Twitter or directly
 join our Gitter.
 
-You always can help me (Florian, the original developer and maintainer) out by 
+You always can help me (Florian, the original developer and maintainer) out by
 [sending me an Euro or two](https://paypal.me/florianec/2).
 
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "~2.4|~3.0",
         "symfony/dependency-injection": "~2.4|~3.0",
         "symfony/http-kernel": "~2.4|~3.0",
-        "twig/twig": "~1.12",
+        "twig/twig": "~1.26|~2.0",
         "zendframework/zend-modulemanager": "~2.2",
         "zendframework/zend-servicemanager": "~2.2",
         "zendframework/zend-view": "~2.2"

--- a/src/Bridge/Twig/SlugifyExtension.php
+++ b/src/Bridge/Twig/SlugifyExtension.php
@@ -66,12 +66,4 @@ class SlugifyExtension extends \Twig_Extension
     {
         return $this->slugify->slugify($string, $separator);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getName()
-    {
-        return 'slugify_extension';
-    }
 }

--- a/tests/Bridge/Silex/SlugifySilexProviderTest.php
+++ b/tests/Bridge/Silex/SlugifySilexProviderTest.php
@@ -12,6 +12,7 @@
 namespace Cocur\Slugify\Tests\Bridge\Silex;
 
 use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
+use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
 
@@ -54,6 +55,6 @@ class SlugifySilexProviderTest extends \PHPUnit_Framework_TestCase
         $app->register(new TwigServiceProvider());
         $app->register(new SlugifyServiceProvider());
 
-        $this->assertTrue($app['twig']->hasExtension('slugify_extension'));
+        $this->assertTrue($app['twig']->hasExtension(SlugifyExtension::class));
     }
 }

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -46,15 +46,6 @@ class SlugifyExtensionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Cocur\Slugify\Bridge\Twig\SlugifyExtension::getName()
-     */
-    public function getNameReturnsNameOfExtension()
-    {
-        $this->assertEquals('slugify_extension', $this->extension->getName());
-    }
-
-    /**
-     * @test
      * @covers Cocur\Slugify\Bridge\Twig\SlugifyExtension::getFilters()
      */
     public function getFilters()


### PR DESCRIPTION
Hello,
This PR adds support for Twig 2.
The failing test in the PR #147 should be green now (related to `Twig_ExtensionInterface::getName`)