### PR TITLE
Use Slugify's defaults rather than having default values in Symfony's configuration

### DIFF
--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -38,6 +38,10 @@ class CocurSlugifyExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        if (empty($config['rulesets'])) {
+            unset($config['rulesets']);
+        }
+
         // Extract slugify arguments from config
         $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'separator', 'regexp', 'rulesets']));
 

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -26,8 +26,8 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->booleanNode('lowercase')->defaultTrue()->end()
-                ->scalarNode('separator')->defaultValue('-')->end()
+                ->booleanNode('lowercase')->end()
+                ->scalarNode('separator')->end()
                 ->scalarNode('regexp')->end()
                 ->arrayNode('rulesets')->prototype('scalar')->end()
             ->end();


### PR DESCRIPTION
Fixes #136.

Does mean that's it's impossible to have an empty `rulesets` option (is that meant to be possible?). With PHP 5.6 the default list could be a static array and then Symfony set to use that as the default value instead, but the minimum requirement is currently 5.5.