### PR TITLE
Fix deprecation notice for Symfony Bridge

### DIFF
--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * CocurSlugifyExtension
@@ -57,5 +58,10 @@ class CocurSlugifyExtension extends Extension
             ->addTag('twig.extension')
             ->setPublic(false);
         $container->setAlias('slugify', 'cocur_slugify');
+
+        // for symfony versions > 3.3
+        if (Kernel::VERSION_ID > 30300) {
+            $container->setAlias('Cocur\Slugify\Slugify', 'cocur_slugify');
+        }
     }
 }


### PR DESCRIPTION
It may need unit tests, but i'm not very familiar with these. Anyway, this fixes the #179 issue with symfony version greater than 3.3
https://symfony.com/doc/current/service_container/3.3-di-changes.html