### PR TITLE
Add link from installation section to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ composer require cocur/slugify
 Slugify requires the Multibyte String extension from PHP. Typically you can use the configure option `--enable-mbstring` while compiling PHP. More information can be found in the [PHP documentation](http://php.net/manual/en/mbstring.installation.php).
  
 
+Further steps may be needed for [integrations](#integrations).
+
 Usage
 -----
 


### PR DESCRIPTION
For those wanting to use slugify in Twig etc., it'd be useful to have a link from the general installation section to the integration-specific steps.