### PR TITLE
Add trim option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ $slugify = new Slugify(['separator' => '_']);
 $slugify->slugify('Hello World'); // -> "hello_world"
 ```
 
+By default Slugify will remove leading and trailing separators before returning the slug. If you do not want the slug to 
+be trimmed you can set the `trim` option to false.
+
+```php
+$slugify = new Slugify(['trim' => false]);
+$slugify->slugify('Hello World '); // -> "hello-world-"
+```
+
 ### Changing options on the fly
 
 You can overwrite any of the above options on the fly by passing an options array as second argument to the `slugify()`

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('lowercase')->end()
+                ->booleanNode('trim')->end()
                 ->scalarNode('separator')->end()
                 ->scalarNode('regexp')->end()
                 ->arrayNode('rulesets')->prototype('scalar')->end()

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -45,6 +45,7 @@ class Slugify implements SlugifyInterface
         'regexp'    => self::LOWERCASE_NUMBERS_DASHES,
         'separator' => '-',
         'lowercase' => true,
+        'trim' => true,
         'rulesets'  => [
             'default',
             // Languages are preferred if they appear later, list is ordered by number of
@@ -119,7 +120,9 @@ class Slugify implements SlugifyInterface
 
         $string = preg_replace($options['regexp'], $options['separator'], $string);
 
-        return trim($string, $options['separator']);
+        return ($options['trim'])
+            ? trim($string, $options['separator'])
+            : $string;
     }
 
     /**

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -207,6 +207,9 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('file-name', $this->slugify->slugify('FILE NAME'));
         $this->assertEquals('FILE-NAME', $this->slugify->slugify('FILE NAME', ['lowercase' => false]));
+
+        $this->assertEquals('file-name', $this->slugify->slugify('file name '));
+        $this->assertEquals('file-name-', $this->slugify->slugify('file name ', ['trim' => false]));
     }
 
     /**


### PR DESCRIPTION
## What? Why? 
Adds `trim` as an available option which allows the user to specify whether or not the slug should be trimmed. By default this still trims the separator from the slug before returning.

If the trim option is set to false, the slug will not be trimmed and will return exactly as it was after `preg_replace()`.

### NOTE
I attempted to make sure all framework integrations were updated, but if I missed something let me know!

