### PR TITLE
Fix AppVeyor Build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php71;%PATH%
 
 environment:
   matrix:
@@ -18,7 +18,7 @@ install:
   - sc config wuauserv start= auto
   - net start wuauserv
   - cinst -y php
-  - cd c:\tools\php
+  - cd c:\tools\php71
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,8 @@ environment:
 
 install:
   - cinst -y OpenSSL.Light
+  - sc config wuauserv start= auto
+  - net start wuauserv
   - cinst -y php
   - cd c:\tools\php
   - copy php.ini-production php.ini /Y


### PR DESCRIPTION
This PR fixes AppVeyor build problems, where PHP indirect dependencies (KB3035131) are returning some errors because Windows Update Service is not properly restarted.

Related #192
Fix #157 

Related jberezanski/ChocolateyPackages#20