### PR TITLE
Fix AppVeyor build and use PHP 7.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php71;%PATH%
+  - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
 
 environment:
   matrix:
@@ -17,22 +17,19 @@ install:
   - cinst -y OpenSSL.Light
   - sc config wuauserv start= auto
   - net start wuauserv
-  - cinst -y php
-  - cd c:\tools\php71
+  - cinst -y php --params "/InstallDir:C:\tools\php"
+  - cd C:\tools\php
   - copy php.ini-production php.ini /Y
-  - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
   - echo extension=php_openssl.dll >> php.ini
   - echo extension=php_mbstring.dll >> php.ini
-  - echo extension=php_fileinfo.dll >> php.ini
-  - echo memory_limit=1G >> php.ini
-  - cd c:\projects\cocur\slugify
-  - php -r "readfile('http://getcomposer.org/installer');" | php
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - php -r "readfile('https://getcomposer.org/installer');" | php
   - php composer.phar update %COMPOSER_FLAGS% --no-interaction --no-progress
 
 test_script:
-  - cd c:\projects\cocur\slugify
-  - vendor\bin\phpunit.bat --verbose
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - vendor\bin\phpunit --verbose --colors=always
 
 notifications:
   - provider: Webhook


### PR DESCRIPTION
Updated to use PHP 7.2 (it is now installed by default by `cinst`). Also removed some unnecessary settings.