### PR TITLE
Add strip_tags option

### DIFF
--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -44,7 +44,7 @@ class CocurSlugifyExtension extends Extension
         }
 
         // Extract slugify arguments from config
-        $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'separator', 'regexp', 'rulesets']));
+        $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'trim', 'strip_tags', 'separator', 'regexp', 'rulesets']));
 
         $container->setDefinition('cocur_slugify', new Definition('Cocur\Slugify\Slugify', [$slugifyArguments]));
         $container

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('lowercase')->end()
                 ->booleanNode('trim')->end()
+                ->booleanNode('strip_tags')->end()
                 ->scalarNode('separator')->end()
                 ->scalarNode('regexp')->end()
                 ->arrayNode('rulesets')->prototype('scalar')->end()

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -46,6 +46,7 @@ class Slugify implements SlugifyInterface
         'separator' => '-',
         'lowercase' => true,
         'trim' => true,
+        'strip_tags' => false,
         'rulesets'  => [
             'default',
             // Languages are preferred if they appear later, list is ordered by number of
@@ -110,6 +111,10 @@ class Slugify implements SlugifyInterface
         } else {
             $rules = $this->rules;
         }
+
+        $string = ($options['strip_tags'])
+            ? strip_tags($string)
+            : $string;
 
         $string = strtr($string, $rules);
         unset($rules);

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -21,6 +21,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $configs = [
             [
                 'lowercase' => true,
+                'strip_tags' => false,
                 'separator' => '_',
                 'regexp' => 'abcd',
                 'rulesets' => ['burmese', 'hindi']
@@ -36,6 +37,15 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testLowercaseOnlyAcceptsBoolean()
     {
         $configs = [['lowercase' => 'abc']];
+        $this->process($configs);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     */
+    public function testStripTagsOnlyAcceptsBoolean()
+    {
+        $configs = [['strip_tags' => 'abc']];
         $this->process($configs);
     }
 

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -211,6 +211,10 @@ class SlugifyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('file-name', $this->slugify->slugify('file name '));
         $this->assertEquals('file-name-', $this->slugify->slugify('file name ', ['trim' => false]));
+
+        $this->assertEquals('file-name', $this->slugify->slugify('<file name'));
+        $this->assertEquals('p-file-p-foo-a-href-bar-name-a', $this->slugify->slugify('<p>file</p><!-- foo --> <a href="#bar">name</a>'));
+        $this->assertEquals('file-name', $this->slugify->slugify('<p>file</p><!-- foo --> <a href="#bar">name</a>', ['strip_tags' => true]));
     }
 
     /**


### PR DESCRIPTION
Adds in an option to go through `strip_tags()` in case the string contains HTML etc.

I've not enabled it by default to avoid problems if using '<' etc on their own.