### PR TITLE
Add lowercase_after_regexp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ $slugify = new Slugify(['lowercase' => false]);
 $slugify->slugify('Hello World'); // -> "Hello-World"
 ```
 
+Lowercasing is done before using the regular expression. If you want to keep the lowercasing behavior but your regular
+expression needs to match uppercase letters, you can set the `lowercase_after_regexp` option to `true`.
+
+```php
+$slugify = new Slugify([
+    'regexp' => '/(?<=[[:^upper:]])(?=[[:upper:]])/',
+    'lowercase_after_regexp' => false,
+]);
+$slugify->slugify('FooBar'); // -> "foo-bar"
+```
+
 By default Slugify will use dashes as separators. If you want to use a different default separator, you can set the
 `separator` option.
 

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('lowercase')->end()
+                ->booleanNode('lowercase_after_regexp')->end()
                 ->booleanNode('trim')->end()
                 ->booleanNode('strip_tags')->end()
                 ->scalarNode('separator')->end()

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -45,6 +45,7 @@ class Slugify implements SlugifyInterface
         'regexp'    => self::LOWERCASE_NUMBERS_DASHES,
         'separator' => '-',
         'lowercase' => true,
+        'lowercase_after_regexp' => false,
         'trim' => true,
         'strip_tags' => false,
         'rulesets'  => [
@@ -119,11 +120,15 @@ class Slugify implements SlugifyInterface
         $string = strtr($string, $rules);
         unset($rules);
 
-        if ($options['lowercase']) {
+        if ($options['lowercase'] && !$options['lowercase_after_regexp']) {
             $string = mb_strtolower($string);
         }
 
         $string = preg_replace($options['regexp'], $options['separator'], $string);
+
+        if ($options['lowercase'] && $options['lowercase_after_regexp']) {
+            $string = mb_strtolower($string);
+        }
 
         return ($options['trim'])
             ? trim($string, $options['separator'])

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -22,6 +22,7 @@ class ConfigurationTest extends TestCase
         $configs = [
             [
                 'lowercase' => true,
+                'lowercase_after_regexp' => false,
                 'strip_tags' => false,
                 'separator' => '_',
                 'regexp' => 'abcd',
@@ -38,6 +39,15 @@ class ConfigurationTest extends TestCase
     public function testLowercaseOnlyAcceptsBoolean()
     {
         $configs = [['lowercase' => 'abc']];
+        $this->process($configs);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     */
+    public function testLowercaseAfterRegexpOnlyAcceptsBoolean()
+    {
+        $configs = [['lowercase_after_regexp' => 'abc']];
         $this->process($configs);
     }
 

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -272,4 +272,44 @@ class SlugifyTest extends TestCase
             ['Ą Č Ę Ė Į Š Ų Ū Ž ą č ę ė į š ų ū ž', 'a-c-e-e-i-s-u-u-z-a-c-e-e-i-s-u-u-z'],
         ];
     }
+
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyLowercaseNotAfterRegexp()
+    {
+        $slugify = new Slugify();
+
+        // Matches any non-uppercase letter followed by an uppercase letter,
+        // which means it  must be used before lowercasing the result.
+        $regexp = '/(?<=[[:^upper:]])(?=[[:upper:]])/';
+
+        $this->assertSame('foobar', $slugify->slugify('FooBar', [
+            'regexp' => $regexp,
+            'lowercase' => true,
+            'lowercase_after_regexp' => false,
+            'separator' => '_',
+        ]));
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Slugify\Slugify::slugify()
+     */
+    public function slugifyLowercaseAfterRegexp()
+    {
+        $slugify = new Slugify();
+
+        // Matches any non-uppercase letter followed by an uppercase letter,
+        // which means it  must be used before lowercasing the result.
+        $regexp = '/(?<=[[:^upper:]])(?=[[:upper:]])/';
+
+        $this->assertSame('foo_bar', $slugify->slugify('FooBar', [
+            'regexp' => $regexp,
+            'lowercase' => true,
+            'lowercase_after_regexp' => true,
+            'separator' => '_',
+        ]));
+    }
 }


### PR DESCRIPTION
This PR adds a new `lowercase_after_regexp` option that allows matching uppercase letters with the regular expression while still relying on `Slugify` to lowercase the slug. My use case is to slugify some class names, e.g. `FooBar` => `foo_bar`.