### PR TITLE
Simplify default regular expression

### DIFF
--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -26,7 +26,7 @@ use Cocur\Slugify\RuleProvider\RuleProviderInterface;
  */
 class Slugify implements SlugifyInterface
 {
-    const LOWERCASE_NUMBERS_DASHES = '/([^A-Za-z0-9]|-)+/';
+    const LOWERCASE_NUMBERS_DASHES = '/[^A-Za-z0-9]+/';
 
     /**
      * @var array<string,string>


### PR DESCRIPTION
`-` is already matched by `[^A-Za-z0-9]` so the regular expression can be simplified.

This does not require a new minor release and could be included in a patch one but I don't know whether lower branches are still maintained so I'm targetting master for now. Please let me know if I should rebase onto another branch.