### PR TITLE
exclude files on tagging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.* export-ignore
+*.md export-ignore
+tests export-ignore


### PR DESCRIPTION
No need to ship tests, MD-files and tool configs