### PR TITLE
Added auto discovery for Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,15 @@
     },
     "autoload-dev": {
         "psr-4": {"Cocur\\Slugify\\Tests\\": "tests"}
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Cocur\\Slugify\\Bridge\\Laravel\\SlugifyServiceProvider"
+            ],
+            "aliases": {
+                "Slugify": "Cocur\\Slugify\\Bridge\\Laravel\\SlugifyFacade"
+            }
+        }
     }
 }


### PR DESCRIPTION
Removes the need to manually register the service provider and facade in Laravel 5.5 and up.

https://laravel.com/docs/5.7/packages#package-discovery