### PR TITLE
Make Twig Bridge compatible with Twig 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,13 @@
         "symfony/config": "~2.4|~3.0|~4.0",
         "symfony/dependency-injection": "~2.4|~3.0|~4.0",
         "symfony/http-kernel": "~2.4|~3.0|~4.0",
-        "twig/twig": "~1.26|~2.0",
+        "twig/twig": "^1.38.1|^2.12.1|~3.0",
         "zendframework/zend-modulemanager": "~2.2",
         "zendframework/zend-servicemanager": "~2.2",
         "zendframework/zend-view": "~2.2"
+    },
+    "conflict": {
+        "twig/twig": ">=1,<1.38.1|>=2,<2.12.1"
     },
     "autoload": {
         "psr-4": {"Cocur\\Slugify\\": "src"}

--- a/src/Bridge/Twig/SlugifyExtension.php
+++ b/src/Bridge/Twig/SlugifyExtension.php
@@ -12,7 +12,8 @@
 namespace Cocur\Slugify\Bridge\Twig;
 
 use Cocur\Slugify\SlugifyInterface;
-use Twig_SimpleFilter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * SlugifyExtension
@@ -23,7 +24,7 @@ use Twig_SimpleFilter;
  * @copyright  2012-2015 Florian Eckerstorfer
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  */
-class SlugifyExtension extends \Twig_Extension
+class SlugifyExtension extends AbstractExtension
 {
     /**
      * @var SlugifyInterface
@@ -45,12 +46,12 @@ class SlugifyExtension extends \Twig_Extension
     /**
      * Returns the Twig functions of this extension.
      *
-     * @return Twig_SimpleFilter[]
+     * @return TwigFilter[]
      */
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter('slugify', [$this, 'slugifyFilter']),
+            new TwigFilter('slugify', [$this, 'slugifyFilter']),
         ];
     }
 

--- a/tests/Bridge/Silex/SlugifySilexProviderTest.php
+++ b/tests/Bridge/Silex/SlugifySilexProviderTest.php
@@ -52,6 +52,10 @@ class SlugifySilexProviderTest extends MockeryTestCase
      */
     public function registerWithTwig()
     {
+        if (!class_exists('\Twig_Environment')) {
+            $this->markTestSkipped('Silex is not compatible with Twig 3');
+        }
+
         $app = new Application();
         $app->register(new TwigServiceProvider());
         $app->register(new SlugifyServiceProvider());

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -53,7 +53,7 @@ class SlugifyExtensionTest extends MockeryTestCase
         $filters = $this->extension->getFilters();
 
         $this->assertCount(1, $filters);
-        $this->assertInstanceOf('\Twig_SimpleFilter', $filters[0]);
+        $this->assertInstanceOf('\Twig\TwigFilter', $filters[0]);
     }
 
     /**


### PR DESCRIPTION
Twig provides namespaced class aliases since 1.38.1 and 2.12.1, so this should work on all recently released Twig versions.