### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 sudo: false
@@ -31,7 +33,7 @@ before_install:
   - travis_retry composer self-update && composer --version
 
 install:
-  - travis_retry composer update $COMPOSER_FLAGS --prefer-source -n
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update $COMPOSER_FLAGS --prefer-source -n
 
 script: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "latte/latte": "~2.2",
         "league/container": "^2.2.0",
         "mikey179/vfsStream": "~1.6",
-        "mockery/mockery": "~0.9",
+        "mockery/mockery": "^0.9.11 || ^1.3",
         "nette/di": "~2.2",
         "phpunit/phpunit": "~4.8.36|~5.2",
         "pimple/pimple": "~1.1",

--- a/tests/Bridge/Laravel/SlugifyProviderTest.php
+++ b/tests/Bridge/Laravel/SlugifyProviderTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\Bridge\Laravel;
 
 use Cocur\Slugify\Bridge\Laravel\SlugifyServiceProvider;
 use Illuminate\Foundation\Application;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyServiceProviderTest
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyProviderTest extends TestCase
+class SlugifyProviderTest extends MockeryTestCase
 {
     /** @var Application */
     private $app;

--- a/tests/Bridge/Latte/SlugifyHelperTest.php
+++ b/tests/Bridge/Latte/SlugifyHelperTest.php
@@ -4,7 +4,7 @@ namespace Cocur\Slugify\Tests\Bridge\Latte;
 
 use Cocur\Slugify\Bridge\Latte\SlugifyHelper;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyHelperTest
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyHelperTest extends TestCase
+class SlugifyHelperTest extends MockeryTestCase
 {
     protected function setUp()
     {

--- a/tests/Bridge/League/SlugifyServiceProviderTest.php
+++ b/tests/Bridge/League/SlugifyServiceProviderTest.php
@@ -8,9 +8,9 @@ use Cocur\Slugify\RuleProvider\RuleProviderInterface;
 use Cocur\Slugify\SlugifyInterface;
 use League\Container\Container;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SlugifyServiceProviderTest extends TestCase
+class SlugifyServiceProviderTest extends MockeryTestCase
 {
     public function testProvidesSlugify()
     {

--- a/tests/Bridge/Nette/SlugifyExtensionTest.php
+++ b/tests/Bridge/Nette/SlugifyExtensionTest.php
@@ -4,7 +4,7 @@ namespace Cocur\Slugify\Tests\Bridge\Nette;
 
 use Cocur\Slugify\Bridge\Nette\SlugifyExtension;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyExtensionTest
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyExtensionTest extends TestCase
+class SlugifyExtensionTest extends MockeryTestCase
 {
     protected function setUp()
     {

--- a/tests/Bridge/Plum/SlugifyConverterTest.php
+++ b/tests/Bridge/Plum/SlugifyConverterTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\Bridge\Plum;
 
 use Cocur\Slugify\Bridge\Plum\SlugifyConverter;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyConverterTest
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright 2012-2015 Florian Eckerstorfer
  * @group     unit
  */
-class SlugifyConverterTest extends TestCase
+class SlugifyConverterTest extends MockeryTestCase
 {
     /**
      * @test

--- a/tests/Bridge/Silex/SlugifySilexProviderTest.php
+++ b/tests/Bridge/Silex/SlugifySilexProviderTest.php
@@ -15,7 +15,7 @@ use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
 use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyServiceProviderTest
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifySilexProviderTest extends TestCase
+class SlugifySilexProviderTest extends MockeryTestCase
 {
     /**
      * @test

--- a/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyBundleTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
 use Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle;
 use Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * CocurSlugifyBundleTest
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class CocurSlugifyBundleTest extends TestCase
+class CocurSlugifyBundleTest extends MockeryTestCase
 {
     /**
      * @covers Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle::getContainerExtension()

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
 use Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * CocurSlugifyExtensionTest
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class CocurSlugifyExtensionTest extends TestCase
+class CocurSlugifyExtensionTest extends MockeryTestCase
 {
     protected function setUp()
     {

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -13,9 +13,9 @@ namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
 use Cocur\Slugify\Bridge\Symfony\Configuration;
 use Symfony\Component\Config\Definition\Processor;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class ConfigurationTest extends TestCase
+class ConfigurationTest extends MockeryTestCase
 {
     public function testAll()
     {

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\Bridge\Twig;
 
 use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyExtensionTest
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  * @group      unit
  */
-class SlugifyExtensionTest extends TestCase
+class SlugifyExtensionTest extends MockeryTestCase
 {
     /**
      * @var \Cocur\Slugify\SlugifyInterface|\Mockery\MockInterface

--- a/tests/Bridge/ZF2/ModuleTest.php
+++ b/tests/Bridge/ZF2/ModuleTest.php
@@ -2,7 +2,7 @@
 namespace Cocur\Slugify\Tests\Bridge\ZF2;
 
 use Cocur\Slugify\Bridge\ZF2\Module;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Class ModuleTest
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  * @subpackage bridge
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  */
-class ModuleTest extends TestCase
+class ModuleTest extends MockeryTestCase
 {
     /**
      * @var Module

--- a/tests/Bridge/ZF2/SlugifyServiceTest.php
+++ b/tests/Bridge/ZF2/SlugifyServiceTest.php
@@ -4,7 +4,7 @@ namespace Cocur\Slugify\Tests\Bridge\ZF2;
 use Cocur\Slugify\Bridge\ZF2\Module;
 use Cocur\Slugify\Bridge\ZF2\SlugifyService;
 use Zend\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Class SlugifyServiceTest
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  * @subpackage bridge
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  */
-class SlugifyServiceTest extends TestCase
+class SlugifyServiceTest extends MockeryTestCase
 {
     /**
      * @var SlugifyService

--- a/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
@@ -5,7 +5,7 @@ use Cocur\Slugify\Bridge\ZF2\SlugifyViewHelperFactory;
 use Cocur\Slugify\Slugify;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Class SlugifyViewHelperFactoryTest
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  * @subpackage bridge
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  */
-class SlugifyViewHelperFactoryTest extends TestCase
+class SlugifyViewHelperFactoryTest extends MockeryTestCase
 {
     /**
      * @var SlugifyViewHelperFactory

--- a/tests/Bridge/ZF2/SlugifyViewHelperTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperTest.php
@@ -3,7 +3,7 @@ namespace Cocur\Slugify\Tests\Bridge\ZF2;
 
 use Cocur\Slugify\Bridge\ZF2\SlugifyViewHelper;
 use Cocur\Slugify\Slugify;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Class SlugifyViewHelperTest
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  * @subpackage bridge
  * @license    http://www.opensource.org/licenses/MIT The MIT License
  */
-class SlugifyViewHelperTest extends TestCase
+class SlugifyViewHelperTest extends MockeryTestCase
 {
     /**
      * @var SlugifyViewHelper

--- a/tests/RuleProvider/FileRuleProviderTest.php
+++ b/tests/RuleProvider/FileRuleProviderTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests\RuleProvider;
 
 use Cocur\Slugify\RuleProvider\FileRuleProvider;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * FileRuleProviderTest
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright 2015 Florian Eckerstorfer
  * @group     unit
  */
-class FileRuleProviderTest extends TestCase
+class FileRuleProviderTest extends MockeryTestCase
 {
     /**
      * @test

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -13,7 +13,7 @@ namespace Cocur\Slugify\Tests;
 
 use Cocur\Slugify\Slugify;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * SlugifyTest
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright 2012-2014 Florian Eckerstorfer
  * @license   http://www.opensource.org/licenses/MIT The MIT License
  */
-class SlugifyTest extends TestCase
+class SlugifyTest extends MockeryTestCase
 {
     /**
      * @var Slugify


### PR DESCRIPTION
**Minimal** changes to make Travis CI work:
 - Ubuntu Xenial does not support PHP 5.4 and 5.5 and [since](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) it's the default environment we have to define Trusty in config
 - increase memory limit for composer
 - upgrading mockery to stable version to fix `PHP Fatal error:  Declaration of Mockery_2_Nette_DI_ServiceDefinition::__isset($name) must be compatible with Nette\DI\ServiceDefinition::__isset(string $name): bool in vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php(16) : eval()'d code on line 25`

----
In separate PR:
~~`composer self-update` is made by Travis CI itself, no need to do it 2nd time~~
~~disabling Xdebug - not needed and slows down - especially 5.x - jobs~~
~~using Prestissimo to speed up jobs~~