### PR TITLE
Improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,21 @@ dist: trusty
 
 language: php
 
-sudo: false
-
 matrix:
   include:
     - php: 5.5.9
     - php: 5.5
     - php: 5.5
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 5.6
     - php: 5.6
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.0
     - php: 7.0
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
     - php: 7.1
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
     - php: nightly
   allow_failures:
@@ -27,13 +25,13 @@ matrix:
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer
 
 before_install:
-  - travis_retry composer self-update && composer --version
+  - composer global outdated --strict hirak/prestissimo || composer global require hirak/prestissimo
 
 install:
-  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update $COMPOSER_FLAGS --prefer-source -n
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update $COMPOSER_FLAGS --no-suggest
 
 script: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
 


### PR DESCRIPTION
 - removing `sudo: false` as [recommended](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) by Travis CI
 - remove `--prefer-stable` CI flag as `composer.json` is not allowing other stabilities anyway
 - cache whole `composer` directory instead of only it's `cache` subdirectory
 - remove `composer self-update` as it is made by Travis CI itself, no need to do it twice
 - add using [`prestissimo`](https://github.com/hirak/prestissimo) to speed up the install
 - clean up `composer update` flags