### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
-.* export-ignore
-*.md export-ignore
-tests export-ignore
+/bin/ export-ignore
+/Resources/ export-ignore
+/tests/ export-ignore
+/.* export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
- exclude `bin` and `Resources` directories - they are not needed in release
- exclude `phpunit.xml.dist`
- do not exclude `README.md` - some might want to look at it, also I've never seen anyone else excluding it