### PR TITLE
Updated Nette DI bridge for compatibility with Nette Framework 3

### DIFF
--- a/src/Bridge/Nette/SlugifyExtension.php
+++ b/src/Bridge/Nette/SlugifyExtension.php
@@ -3,6 +3,7 @@
 namespace Cocur\Slugify\Bridge\Nette;
 
 use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\FactoryDefinition;
 use Nette\DI\ServiceDefinition;
 
 /**
@@ -33,8 +34,8 @@ class SlugifyExtension extends CompilerExtension
         $builder = $this->getContainerBuilder();
 
         $self = $this;
-        $registerToLatte = function (ServiceDefinition $def) use ($self) {
-            $def->addSetup('addFilter', ['slugify', [$self->prefix('@helper'), 'slugify']]);
+        $registerToLatte = function (FactoryDefinition $def) use ($self) {
+            $def->getResultDefinition()->addSetup('addFilter', ['slugify', [$self->prefix('@helper'), 'slugify']]);
         };
 
         $latteFactory = $builder->getByType('Nette\Bridges\ApplicationLatte\ILatteFactory') ?: 'nette.latteFactory';


### PR DESCRIPTION
Hey,
I have updated the Nette DI bridge (Cocur\Slugify\Bridge\Nette\SlugifyExtension).

I do not, however, write tests much and I generally don't use Mockery either, so I was unable to update the test.