### PR TITLE
Update SlugifyInterface.php

### DIFF
--- a/src/SlugifyInterface.php
+++ b/src/SlugifyInterface.php
@@ -33,4 +33,6 @@ interface SlugifyInterface
      * @api
      */
     public function slugify($string, $options = null);
+    
+    public function addRule($character, $replacement);
 }


### PR DESCRIPTION
When injecting the library with typehint `Cocur\Slugify\SlugifyInterface` (as recommended in README), I'm getting this error from [PhpStan](https://phpstan.org/) when I do `$this->slugify->addRule(...);`:

> Call to an undefined method Cocur\Slugify\SlugifyInterface::addRule()

This PR fixes it, but I guess the other methods of `Slugify` (`activateRuleSet()` etc.) should be added too?