### PR TITLE
More Yoruba character support

### DIFF
--- a/src/RuleProvider/DefaultRuleProvider.php
+++ b/src/RuleProvider/DefaultRuleProvider.php
@@ -7468,6 +7468,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'Ș' => 'S',
     'ŝ' => 's',
     'ș' => 's',
+    'Ṣ' => 'S',
     'ṣ' => 's',
     'ſ' => 's',
     'Ţ' => 'T',

--- a/src/RuleProvider/DefaultRuleProvider.php
+++ b/src/RuleProvider/DefaultRuleProvider.php
@@ -7468,6 +7468,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'Ș' => 'S',
     'ŝ' => 's',
     'ș' => 's',
+    'ṣ' => 's',
     'ſ' => 's',
     'Ţ' => 'T',
     'Ț' => 'T',


### PR DESCRIPTION
Note: 
ṣ is different from ș