### PR TITLE
Allow Symfony 6 and resolve depreciations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ cache:
 
 init:
   - SET PATH=C:\tools\php;%PATH%
+  - SET COMPOSER_BINARY=C:\tools\composer.phar
 
 install:
   - ps: Set-Service wuauserv -StartupType Manual
@@ -24,9 +25,8 @@ install:
   - echo memory_limit=3G >> php.ini
   - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/composer.phar)
   - cd %APPVEYOR_BUILD_FOLDER%
-  - php C:\tools\composer.phar global show hirak/prestissimo --quiet || php C:\tools\composer.phar global require hirak/prestissimo --no-progress
-  - php C:\tools\composer.phar update --no-ansi --no-interaction --no-progress --no-suggest --optimize-autoloader --prefer-stable
+  - php C:\tools\composer.phar update --no-interaction --no-progress --optimize-autoloader --prefer-stable
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - php vendor\phpunit\phpunit\phpunit
+  - php vendor\bin\simple-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
 /.php_cs.cache
+.phpunit.result.cache
 /composer.lock
 /phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.0
-    - php: 7.0
-      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest'
@@ -17,8 +14,14 @@ matrix:
     - php: 7.3
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS='--prefer-lowest'
+    - php: 8.0
+    - php: 8.0
+      env: COMPOSER_FLAGS='--prefer-lowest'
+    - php: 8.1
       env: ANALYSIS=1
-    - php: 7.4
+    - php: 8.1
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: nightly
   allow_failures:
@@ -34,7 +37,7 @@ install:
   - if [ $ANALYSIS == 1 ]; then travis_retry composer update --working-dir=./dev-tools --no-suggest; fi
 
 script:
-  - vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
+  - vendor/bin/simple-phpunit --verbose --coverage-clover=coverage.clover
   - if [ $ANALYSIS == 1 ]; then ./dev-tools/analyse.sh || travis_terminate 1; fi
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-mbstring": "*"
     },
     "conflict": {
@@ -35,12 +35,12 @@
         "mikey179/vfsstream": "~1.6.8",
         "mockery/mockery": "^1.3",
         "nette/di": "~2.4",
-        "phpunit/phpunit": "^5.7.27",
         "pimple/pimple": "~1.1",
         "plumphp/plum": "~0.1",
-        "symfony/config": "^3.4 || ^4.3 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0",
+        "symfony/config": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
         "twig/twig": "^2.12.1 || ~3.0",
         "zendframework/zend-modulemanager": "~2.2",
         "zendframework/zend-servicemanager": "~2.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="vendor/autoload.php" colors="true">
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
+
     <testsuites>
         <testsuite name="cocur/slugify Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <listeners>
         <listener class="\Mockery\Adapter\Phpunit\TestListener" />
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
 </phpunit>

--- a/src/Bridge/League/SlugifyServiceProvider.php
+++ b/src/Bridge/League/SlugifyServiceProvider.php
@@ -14,7 +14,7 @@ class SlugifyServiceProvider extends AbstractServiceProvider
         SlugifyInterface::class,
     ];
 
-    public function register()
+    public function register(): void
     {
         $this->container->share(SlugifyInterface::class, function () {
             $options = [];

--- a/src/Bridge/Nette/SlugifyExtension.php
+++ b/src/Bridge/Nette/SlugifyExtension.php
@@ -15,7 +15,7 @@ use Nette\DI\ServiceDefinition;
  */
 class SlugifyExtension extends CompilerExtension
 {
-    public function loadConfiguration()
+    public function loadConfiguration(): void
     {
         $builder = $this->getContainerBuilder();
 
@@ -28,7 +28,7 @@ class SlugifyExtension extends CompilerExtension
             ->setAutowired(false);
     }
 
-    public function beforeCompile()
+    public function beforeCompile(): void
     {
         $builder = $this->getContainerBuilder();
 

--- a/src/Bridge/Symfony/CocurSlugifyBundle.php
+++ b/src/Bridge/Symfony/CocurSlugifyBundle.php
@@ -11,6 +11,7 @@
 
 namespace Cocur\Slugify\Bridge\Symfony;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class CocurSlugifyBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ExtensionInterface
     {
         return new CocurSlugifyExtension();
     }

--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -11,6 +11,9 @@
 
 namespace Cocur\Slugify\Bridge\Symfony;
 
+use Cocur\Slugify\Bridge\Twig\SlugifyExtension;
+use Cocur\Slugify\Slugify;
+use Cocur\Slugify\SlugifyInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -33,7 +36,7 @@ class CocurSlugifyExtension extends Extension
      * @param mixed[]          $configs
      * @param ContainerBuilder $container
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -45,18 +48,18 @@ class CocurSlugifyExtension extends Extension
         // Extract slugify arguments from config
         $slugifyArguments = array_intersect_key($config, array_flip(['lowercase', 'trim', 'strip_tags', 'separator', 'regexp', 'rulesets']));
 
-        $container->setDefinition('cocur_slugify', new Definition('Cocur\Slugify\Slugify', [$slugifyArguments]));
+        $container->setDefinition('cocur_slugify', new Definition(Slugify::class, [$slugifyArguments]));
         $container
             ->setDefinition(
                 'cocur_slugify.twig.slugify',
                 new Definition(
-                    'Cocur\Slugify\Bridge\Twig\SlugifyExtension',
+                    SlugifyExtension::class,
                     [new Reference('cocur_slugify')]
                 )
             )
             ->addTag('twig.extension')
             ->setPublic(false);
         $container->setAlias('slugify', 'cocur_slugify');
-        $container->setAlias('Cocur\Slugify\SlugifyInterface', 'cocur_slugify');
+        $container->setAlias(SlugifyInterface::class, 'cocur_slugify');
     }
 }

--- a/src/Bridge/Symfony/Configuration.php
+++ b/src/Bridge/Symfony/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('cocur_slugify');
 

--- a/tests/Bridge/Laravel/SlugifyProviderTest.php
+++ b/tests/Bridge/Laravel/SlugifyProviderTest.php
@@ -35,7 +35,7 @@ class SlugifyProviderTest extends MockeryTestCase
     /** @var SlugifyServiceProvider */
     private $provider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->app = new Application();
         $this->provider = new SlugifyServiceProvider($this->app);

--- a/tests/Bridge/Latte/SlugifyHelperTest.php
+++ b/tests/Bridge/Latte/SlugifyHelperTest.php
@@ -18,7 +18,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class SlugifyHelperTest extends MockeryTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->slugify = m::mock('Cocur\Slugify\SlugifyInterface');
         $this->helper = new SlugifyHelper($this->slugify);

--- a/tests/Bridge/League/SlugifyServiceProviderTest.php
+++ b/tests/Bridge/League/SlugifyServiceProviderTest.php
@@ -21,7 +21,7 @@ class SlugifyServiceProviderTest extends MockeryTestCase
         $slugify = $container->get(SlugifyInterface::class);
 
         $this->assertInstanceOf(SlugifyInterface::class, $slugify);
-        $this->assertAttributeInstanceOf(DefaultRuleProvider::class, 'provider', $slugify);
+        $this->assertInstanceOf(DefaultRuleProvider::class, $this->getProperty($slugify, 'provider'));
     }
 
     public function testProvidesSlugifyAsSharedService()
@@ -65,7 +65,7 @@ class SlugifyServiceProviderTest extends MockeryTestCase
 
         $slugify = $container->get(SlugifyInterface::class);
 
-        $this->assertAttributeSame($ruleProvider, 'provider', $slugify);
+        $this->assertSame($ruleProvider, $this->getProperty($slugify, 'provider'));
     }
 
     /**
@@ -82,5 +82,14 @@ class SlugifyServiceProviderTest extends MockeryTestCase
         ;
 
         return $ruleProvider;
+    }
+
+    private function getProperty(SlugifyInterface $slugify, string $name)
+    {
+        $reflection = new \ReflectionClass($slugify);
+        $prop = $reflection->getProperty($name);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($slugify);
     }
 }

--- a/tests/Bridge/Nette/SlugifyExtensionTest.php
+++ b/tests/Bridge/Nette/SlugifyExtensionTest.php
@@ -18,7 +18,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class SlugifyExtensionTest extends MockeryTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extension = new SlugifyExtension();
     }

--- a/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
+++ b/tests/Bridge/Symfony/CocurSlugifyExtensionTest.php
@@ -58,7 +58,7 @@ class CocurSlugifyExtensionTest extends TestCase
             ->method('setDefinition')
             ->withConsecutive(
                 [$this->equalTo('cocur_slugify'), $this->isInstanceOf(Definition::class)],
-                [$this->equalTo('cocur_slugify.twig.slugify', $this->isInstanceOf(Definition::class))]
+                [$this->equalTo('cocur_slugify.twig.slugify'), $this->isInstanceOf(Definition::class)]
             )
             ->willReturnOnConsecutiveCalls(
                 $this->createMock(Definition::class),

--- a/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/ConfigurationTest.php
@@ -12,6 +12,7 @@
 namespace Cocur\Slugify\Tests\Bridge\Symfony;
 
 use Cocur\Slugify\Bridge\Symfony\Configuration;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\Processor;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
@@ -30,32 +31,29 @@ class ConfigurationTest extends MockeryTestCase
             ],
         ];
 
-        $this->process($configs);
+        $this->assertSame($configs[0], $this->process($configs));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
-     */
     public function testLowercaseOnlyAcceptsBoolean()
     {
+        $this->expectException(InvalidTypeException::class);
+
         $configs = [['lowercase' => 'abc']];
         $this->process($configs);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
-     */
     public function testLowercaseAfterRegexpOnlyAcceptsBoolean()
     {
+        $this->expectException(InvalidTypeException::class);
+
         $configs = [['lowercase_after_regexp' => 'abc']];
         $this->process($configs);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
-     */
     public function testStripTagsOnlyAcceptsBoolean()
     {
+        $this->expectException(InvalidTypeException::class);
+
         $configs = [['strip_tags' => 'abc']];
         $this->process($configs);
     }

--- a/tests/Bridge/Twig/SlugifyExtensionTest.php
+++ b/tests/Bridge/Twig/SlugifyExtensionTest.php
@@ -38,7 +38,7 @@ class SlugifyExtensionTest extends MockeryTestCase
      */
     protected $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->slugify = m::mock('Cocur\Slugify\SlugifyInterface');
         $this->extension = new SlugifyExtension($this->slugify);

--- a/tests/Bridge/ZF2/ModuleTest.php
+++ b/tests/Bridge/ZF2/ModuleTest.php
@@ -17,7 +17,7 @@ class ModuleTest extends MockeryTestCase
      */
     private $module;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->module = new Module();
     }
@@ -28,7 +28,7 @@ class ModuleTest extends MockeryTestCase
     public function testGetServiceConfig()
     {
         $smConfig = $this->module->getServiceConfig();
-        $this->assertInternalType('array', $smConfig);
+        $this->assertIsArray($smConfig);
         $this->assertArrayHasKey('factories', $smConfig);
         $this->assertArrayHasKey('Cocur\Slugify\Slugify', $smConfig['factories']);
         $this->assertArrayHasKey('aliases', $smConfig);
@@ -41,7 +41,7 @@ class ModuleTest extends MockeryTestCase
     public function testGetViewHelperConfig()
     {
         $vhConfig = $this->module->getViewHelperConfig();
-        $this->assertInternalType('array', $vhConfig);
+        $this->assertIsArray($vhConfig);
         $this->assertArrayHasKey('factories', $vhConfig);
         $this->assertArrayHasKey('slugify', $vhConfig['factories']);
     }

--- a/tests/Bridge/ZF2/SlugifyServiceTest.php
+++ b/tests/Bridge/ZF2/SlugifyServiceTest.php
@@ -19,7 +19,7 @@ class SlugifyServiceTest extends MockeryTestCase
      */
     private $slugifyService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->slugifyService = new SlugifyService();
     }

--- a/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperFactoryTest.php
@@ -20,7 +20,7 @@ class SlugifyViewHelperFactoryTest extends MockeryTestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new SlugifyViewHelperFactory();
     }

--- a/tests/Bridge/ZF2/SlugifyViewHelperTest.php
+++ b/tests/Bridge/ZF2/SlugifyViewHelperTest.php
@@ -25,7 +25,7 @@ class SlugifyViewHelperTest extends MockeryTestCase
     /**
      * @covers \Cocur\Slugify\Bridge\ZF2\SlugifyViewHelper::__construct()
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->slugify = new Slugify();
         $this->viewHelper = new SlugifyViewHelper($this->slugify);

--- a/tests/SlugifyTest.php
+++ b/tests/SlugifyTest.php
@@ -38,7 +38,7 @@ class SlugifyTest extends MockeryTestCase
      */
     private $provider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->provider = Mockery::mock('\Cocur\Slugify\RuleProvider\RuleProviderInterface');
         $this->provider->shouldReceive('getRules')->andReturn([]);


### PR DESCRIPTION
First, thank you for maintaining this library. I work on a project that uses it and that needs to  be upgraded to Symfony 6.0.

I had to make a lot of updates in order to have tests passing. Please tell me if you prefers separated pull requests, or anything that I should change.

- Remove [hirak/prestissimo](https://github.com/hirak/prestissimo), not necessary since Composer 2 supports parallel downloads.
- Switch to `symfony/simple-phpunit` to get polyfills for [PHPUnit versions](https://phpunit.de/supported-versions.html).
- Require PHP 7.1+ ([`void` return type](https://www.php.net/manual/en/migration71.new-features.php))
- Allow Symfony 6.0 and add return types.
- Replace Mockery with PHPUnit Mock in `Cocur\Slugify\Tests\Bridge\Symfony\CocurSlugifyExtensionTest`, to solve an error `ParseError: syntax error, unexpected token "static", expecting identifier`