### PR TITLE
Add handling for undefined rulesets

### DIFF
--- a/src/RuleProvider/DefaultRuleProvider.php
+++ b/src/RuleProvider/DefaultRuleProvider.php
@@ -11,6 +11,8 @@
 
 namespace Cocur\Slugify\RuleProvider;
 
+use OutOfBoundsException;
+
 /**
  * DefaultRuleProvider
  *
@@ -10309,6 +10311,9 @@ class DefaultRuleProvider implements RuleProviderInterface
      */
     public function getRules($ruleset)
     {
+        if (!array_key_exists($ruleset, $this->rules)) {
+            throw new OutOfBoundsException(sprintf('ruleset \'%s\' does not exist', $ruleset));
+        }
         return $this->rules[$ruleset];
     }
 }


### PR DESCRIPTION
When supplying the `ruleset` option with an unknown ruleset to `\Cocur\Slugify\Slugify::__construct`, the following error occurs:

    Notice: Undefined index: foo in /path/to/vendor/cocur/slugify/src/RuleProvider/DefaultRuleProvider.php on line 8616
    PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Cocur\Slugify\Slugify::addRules() must be of the type array, null given, called in /path/to/vendor/cocur/slugify/src/Slugify.php on line 178 and defined in /path/to/vendor/cocur/slugify/src/Slugify.php:162

This PR detects this and throws and `OutOfBoundsException` instead.