### PR TITLE
Remove unneeded `$`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Developed by [Florian Eckerstorfer](https://florian.ec) in Vienna, Europe with t
 You can install Slugify through [Composer](https://getcomposer.org):
 
 ```shell
-$ composer require cocur/slugify
+composer require cocur/slugify
 ```
 
 Slugify requires the Multibyte String extension from PHP. Typically you can use the configure option `--enable-mbstring` while compiling PHP. More information can be found in the [PHP documentation](http://php.net/manual/en/mbstring.installation.php).


### PR DESCRIPTION
the 
> ``\`shell

syntax in GitHub provides a copy button to the right (on hover) that doesn't work properly if there is a dollar sign infront.
