### PR TITLE
fix: Add types to avoid PHP 8.2 deprecation warning

### DIFF
--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -97,7 +97,7 @@ class Slugify implements SlugifyInterface
      *
      * @return string Slugified version of the string
      */
-    public function slugify($string, $options = null)
+    public function slugify(string $string, $options = null): string
     {
         // BC: the second argument used to be the separator
         if (is_string($options)) {

--- a/src/SlugifyInterface.php
+++ b/src/SlugifyInterface.php
@@ -32,5 +32,5 @@ interface SlugifyInterface
      *
      * @api
      */
-    public function slugify($string, $options = null);
+    public function slugify(string $string, $options = null): string;
 }


### PR DESCRIPTION
Hi team,

I wanted to let you know about a deprecation warning I've been getting in all my projects since updating to PHP 8.2. The warning is related to using nullable types instead of strings.

Here's the link to the PHP 8.1 deprecation notice: [link](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation)

To address this, I think we should improve the types used in the slugify method, but it would be a breaking change.

Another option is to check for null at the beginning of the method and return an empty string in that case. However, I'm not sure if this is the best solution.

Please share your thoughts on whether this approach is correct or if you have any other ideas.

Thanks.