### PR TITLE
feat: strong type all project for support PHP 8+ versions better

### DIFF
--- a/bin/generate-default.php
+++ b/bin/generate-default.php
@@ -5,7 +5,7 @@
  *
  * @return array
  */
-function getRules($directory)
+function getRules($directory): array
 {
     $rules    = [];
     $iterator = new DirectoryIterator($directory);
@@ -25,7 +25,7 @@ function getRules($directory)
  *
  * @return bool
  */
-function insertRules($fileName, array $rules = [])
+function insertRules($fileName, array $rules = []): bool
 {
     $startTag = '/*INSERT_START*/';
     $endTag   = '/*INSERT_END*/';

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,6 +1,11 @@
 {
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
-        "localheinz/composer-normalize": "^1.3"
+        "localheinz/composer-normalize": "^2.34"
+    },
+    "config": {
+        "allow-plugins": {
+            "localheinz/composer-normalize": true
+        }
     }
 }

--- a/src/Bridge/Laravel/SlugifyFacade.php
+++ b/src/Bridge/Laravel/SlugifyFacade.php
@@ -32,7 +32,7 @@ class SlugifyFacade extends Facade
      *
      * @codeCoverageIgnore
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'slugify';
     }

--- a/src/Bridge/Laravel/SlugifyServiceProvider.php
+++ b/src/Bridge/Laravel/SlugifyServiceProvider.php
@@ -38,7 +38,7 @@ class SlugifyServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton('slugify', function () {
             return new Slugify();
@@ -50,7 +50,7 @@ class SlugifyServiceProvider extends LaravelServiceProvider
      *
      * @return string[]
      */
-    public function provides()
+    public function provides(): array
     {
         return ['slugify'];
     }

--- a/src/Bridge/Latte/SlugifyHelper.php
+++ b/src/Bridge/Latte/SlugifyHelper.php
@@ -31,7 +31,7 @@ class SlugifyHelper
      *
      * @return string
      */
-    public function slugify($string, $separator = null)
+    public function slugify($string, $separator = null): string
     {
         return $this->slugify->slugify($string, $separator);
     }

--- a/src/Bridge/Plum/SlugifyConverter.php
+++ b/src/Bridge/Plum/SlugifyConverter.php
@@ -43,7 +43,7 @@ class SlugifyConverter implements ConverterInterface
      *
      * @return string
      */
-    public function convert($item)
+    public function convert($item): string
     {
         return $this->slugify->slugify($item);
     }

--- a/src/Bridge/Twig/SlugifyExtension.php
+++ b/src/Bridge/Twig/SlugifyExtension.php
@@ -48,7 +48,7 @@ class SlugifyExtension extends AbstractExtension
      *
      * @return TwigFilter[]
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('slugify', [$this, 'slugifyFilter']),
@@ -63,7 +63,7 @@ class SlugifyExtension extends AbstractExtension
      *
      * @return string
      */
-    public function slugifyFilter($string, $separator = null)
+    public function slugifyFilter($string, $separator = null): string
     {
         return $this->slugify->slugify($string, $separator);
     }
@@ -73,7 +73,7 @@ class SlugifyExtension extends AbstractExtension
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return "SlugifyExtension";
     }

--- a/src/Bridge/ZF2/Module.php
+++ b/src/Bridge/ZF2/Module.php
@@ -21,7 +21,7 @@ class Module implements ServiceProviderInterface, ViewHelperProviderInterface
      *
      * @return array<string,array<string,string>>
      */
-    public function getServiceConfig()
+    public function getServiceConfig(): array
     {
         return [
             'factories' => [
@@ -39,7 +39,7 @@ class Module implements ServiceProviderInterface, ViewHelperProviderInterface
      *
      * @return array<string,array<string,string>>|\Zend\ServiceManager\Config
      */
-    public function getViewHelperConfig()
+    public function getViewHelperConfig(): array
     {
         return [
             'factories' => [

--- a/src/Bridge/ZF2/SlugifyService.php
+++ b/src/Bridge/ZF2/SlugifyService.php
@@ -18,7 +18,7 @@ class SlugifyService
      *
      * @return Slugify
      */
-    public function __invoke($sm)
+    public function __invoke($sm): Slugify
     {
         $config = $sm->get('Config');
 

--- a/src/Bridge/ZF2/SlugifyViewHelper.php
+++ b/src/Bridge/ZF2/SlugifyViewHelper.php
@@ -34,7 +34,7 @@ class SlugifyViewHelper extends AbstractHelper
      *
      * @return string
      */
-    public function __invoke($string, $separator = null)
+    public function __invoke(string $string, string $separator = null)
     {
         return $this->slugify->slugify($string, $separator);
     }

--- a/src/Bridge/ZF2/SlugifyViewHelperFactory.php
+++ b/src/Bridge/ZF2/SlugifyViewHelperFactory.php
@@ -21,7 +21,7 @@ class SlugifyViewHelperFactory
     public function __invoke($vhm)
     {
         /** @var Slugify $slugify */
-        $slugify = $vhm->getServiceLocator()->get('Cocur\Slugify\Slugify');
+        $slugify = $vhm->getServiceLocator()->get(Slugify::class);
 
         return new SlugifyViewHelper($slugify);
     }

--- a/src/RuleProvider/DefaultRuleProvider.php
+++ b/src/RuleProvider/DefaultRuleProvider.php
@@ -29,8 +29,8 @@ class DefaultRuleProvider implements RuleProviderInterface
      *
      * @var array
      */
-    protected $rules = /*INSERT_START*/array (
-  'arabic' => 
+    protected array $rules = /*INSERT_START*/array (
+  'arabic' =>
   array (
     'أ' => 'a',
     'ب' => 'b',
@@ -61,7 +61,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'و' => 'o',
     'ي' => 'y',
   ),
-  'armenian' => 
+  'armenian' =>
   array (
     'Ա' => 'A',
     'Բ' => 'B',
@@ -141,7 +141,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'օ' => 'o',
     'ֆ' => 'f',
   ),
-  'austrian' => 
+  'austrian' =>
   array (
     'Ä' => 'AE',
     'Ö' => 'OE',
@@ -152,7 +152,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ü' => 'ue',
     'ß' => 'ss',
   ),
-  'azerbaijani' => 
+  'azerbaijani' =>
   array (
     'Ə' => 'E',
     'Ç' => 'C',
@@ -169,7 +169,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ö' => 'o',
     'ü' => 'u',
   ),
-  'bulgarian' => 
+  'bulgarian' =>
   array (
     'А' => 'A',
     'Б' => 'B',
@@ -235,7 +235,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'йо' => 'iо',
     'ьо' => 'io',
   ),
-  'burmese' => 
+  'burmese' =>
   array (
     'က' => 'k',
     'ခ' => 'kh',
@@ -352,7 +352,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ိံ' => 'ein',
     'ုံ' => 'on',
   ),
-  'chinese' => 
+  'chinese' =>
   array (
     '腌' => 'yan',
     '嗄' => 'a',
@@ -7288,7 +7288,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     '螵' => 'piao',
     '蟛' => 'peng',
   ),
-  'croatian' => 
+  'croatian' =>
   array (
     'Č' => 'C',
     'Ć' => 'C',
@@ -7301,7 +7301,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'š' => 's',
     'đ' => 'dj',
   ),
-  'custom-fonts' => 
+  'custom-fonts' =>
   array (
     '͕a͕' => 'a',
     '͕b͕' => 'b',
@@ -9002,7 +9002,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     '𝔜' => 'Y',
     'ℨ' => 'Z',
   ),
-  'czech' => 
+  'czech' =>
   array (
     'Č' => 'C',
     'Ď' => 'D',
@@ -9023,7 +9023,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ů' => 'u',
     'ž' => 'z',
   ),
-  'danish' => 
+  'danish' =>
   array (
     'Æ' => 'Ae',
     'æ' => 'ae',
@@ -9034,7 +9034,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'É' => 'E',
     'é' => 'e',
   ),
-  'default' => 
+  'default' =>
   array (
     '°' => '0',
     '¹' => '1',
@@ -9218,7 +9218,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ÿ' => 'y',
     'ŷ' => 'y',
   ),
-  'esperanto' => 
+  'esperanto' =>
   array (
     'ĉ' => 'cx',
     'ĝ' => 'gx',
@@ -9233,7 +9233,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'Ŝ' => 'SX',
     'Ŭ' => 'UX',
   ),
-  'estonian' => 
+  'estonian' =>
   array (
     'Š' => 'S',
     'Ž' => 'Z',
@@ -9248,14 +9248,14 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ö' => 'o',
     'ü' => 'u',
   ),
-  'finnish' => 
+  'finnish' =>
   array (
     'Ä' => 'A',
     'Ö' => 'O',
     'ä' => 'a',
     'ö' => 'o',
   ),
-  'french' => 
+  'french' =>
   array (
     'À' => 'A',
     'Â' => 'A',
@@ -9290,7 +9290,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ÿ' => 'y',
     'Ÿ' => 'Y',
   ),
-  'georgian' => 
+  'georgian' =>
   array (
     'ა' => 'a',
     'ბ' => 'b',
@@ -9326,7 +9326,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ჯ' => 'j',
     'ჰ' => 'h',
   ),
-  'german' => 
+  'german' =>
   array (
     'Ä' => 'AE',
     'Ö' => 'OE',
@@ -9337,7 +9337,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ü' => 'ue',
     'ß' => 'ss',
   ),
-  'greek' => 
+  'greek' =>
   array (
     'ΑΥ' => 'AU',
     'Αυ' => 'Au',
@@ -9449,7 +9449,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ϐ' => 'v',
     'ϑ' => 'th',
   ),
-  'gujarati' => 
+  'gujarati' =>
   array (
     'અ' => 'a',
     'આ' => 'aa',
@@ -9505,7 +9505,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ં' => 'm',
     'ॐ' => 'oms',
   ),
-  'hindi' => 
+  'hindi' =>
   array (
     'अ' => 'a',
     'आ' => 'aa',
@@ -9572,7 +9572,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'य़' => 'Yi',
     'ज़' => 'Za',
   ),
-  'hungarian' => 
+  'hungarian' =>
   array (
     'Á' => 'a',
     'É' => 'e',
@@ -9593,7 +9593,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ü' => 'u',
     'ű' => 'u',
   ),
-  'italian' => 
+  'italian' =>
   array (
     'À' => 'a',
     'È' => 'e',
@@ -9607,7 +9607,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ò' => 'o',
     'ù' => 'u',
   ),
-  'latvian' => 
+  'latvian' =>
   array (
     'Ā' => 'A',
     'Ē' => 'E',
@@ -9626,7 +9626,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ņ' => 'n',
     'ū' => 'u',
   ),
-  'lithuanian' => 
+  'lithuanian' =>
   array (
     'Ą' => 'A',
     'Č' => 'C',
@@ -9647,7 +9647,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ū' => 'u',
     'ž' => 'z',
   ),
-  'macedonian' => 
+  'macedonian' =>
   array (
     'А' => 'A',
     'Б' => 'B',
@@ -9712,7 +9712,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'џ' => 'dj',
     'ш' => 'sh',
   ),
-  'norwegian' => 
+  'norwegian' =>
   array (
     'Æ' => 'AE',
     'Ø' => 'OE',
@@ -9721,7 +9721,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ø' => 'oe',
     'å' => 'aa',
   ),
-  'persian' => 
+  'persian' =>
   array (
     'ا' => 'a',
     'ب' => 'b',
@@ -9756,7 +9756,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ه' => 'h',
     'ی' => 'y',
   ),
-  'polish' => 
+  'polish' =>
   array (
     'Ą' => 'A',
     'Ć' => 'C',
@@ -9777,7 +9777,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ź' => 'z',
     'ż' => 'z',
   ),
-  'portuguese-brazil' => 
+  'portuguese-brazil' =>
   array (
     '°' => '0',
     '¹' => '1',
@@ -9961,7 +9961,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ÿ' => 'y',
     'ŷ' => 'y',
   ),
-  'romanian' => 
+  'romanian' =>
   array (
     'ă' => 'a',
     'î' => 'i',
@@ -9978,7 +9978,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'Ţ' => 'T',
     'Ț' => 'T',
   ),
-  'russian' => 
+  'russian' =>
   array (
     'Ъ' => '',
     'Ь' => '',
@@ -10047,7 +10047,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'з' => 'z',
     'ж' => 'zh',
   ),
-  'serbian' => 
+  'serbian' =>
   array (
     'а' => 'a',
     'б' => 'b',
@@ -10120,7 +10120,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'Ć' => 'C',
     'Č' => 'C',
   ),
-  'slovak' => 
+  'slovak' =>
   array (
     'Á' => 'A',
     'Ä' => 'A',
@@ -10157,7 +10157,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ý' => 'y',
     'ž' => 'z',
   ),
-  'swedish' => 
+  'swedish' =>
   array (
     'Ä' => 'A',
     'Å' => 'a',
@@ -10166,7 +10166,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'å' => 'a',
     'ö' => 'o',
   ),
-  'turkish' => 
+  'turkish' =>
   array (
     'Ç' => 'C',
     'Ğ' => 'G',
@@ -10181,7 +10181,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ö' => 'o',
     'ü' => 'u',
   ),
-  'turkmen' => 
+  'turkmen' =>
   array (
     'Ç' => 'C',
     'Ä' => 'A',
@@ -10200,7 +10200,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ü' => 'u',
     'ý' => 'y',
   ),
-  'ukrainian' => 
+  'ukrainian' =>
   array (
     'Ґ' => 'G',
     'І' => 'I',
@@ -10211,7 +10211,7 @@ class DefaultRuleProvider implements RuleProviderInterface
     'ї' => 'ji',
     'є' => 'ye',
   ),
-  'vietnamese' => 
+  'vietnamese' =>
   array (
     'ạ' => 'a',
     'ả' => 'a',
@@ -10311,7 +10311,7 @@ class DefaultRuleProvider implements RuleProviderInterface
      *
      * @return array
      */
-    public function getRules($ruleset)
+    public function getRules(string $ruleset): array
     {
         if (!array_key_exists($ruleset, $this->rules)) {
             throw new OutOfBoundsException(sprintf('ruleset \'%s\' does not exist', $ruleset));

--- a/src/RuleProvider/FileRuleProvider.php
+++ b/src/RuleProvider/FileRuleProvider.php
@@ -23,24 +23,24 @@ class FileRuleProvider implements RuleProviderInterface
     /**
      * @var string
      */
-    protected $directoryName;
+    protected string $directoryName;
 
     /**
      * @param string $directoryName
      */
-    public function __construct($directoryName)
+    public function __construct(string $directoryName)
     {
         $this->directoryName = $directoryName;
     }
 
     /**
-     * @param $ruleset
+     * @param string $ruleset
      *
      * @return array
      */
-    public function getRules($ruleset)
+    public function getRules(string $ruleset): array
     {
-        $fileName = $this->directoryName.DIRECTORY_SEPARATOR.$ruleset.'.json';
+        $fileName = $this->directoryName . DIRECTORY_SEPARATOR . $ruleset . '.json';
 
         return json_decode(file_get_contents($fileName), true);
     }

--- a/src/RuleProvider/RuleProviderInterface.php
+++ b/src/RuleProvider/RuleProviderInterface.php
@@ -25,5 +25,5 @@ interface RuleProviderInterface
      *
      * @return array
      */
-    public function getRules($ruleset);
+    public function getRules(string $ruleset): array;
 }

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -26,22 +26,22 @@ use Cocur\Slugify\RuleProvider\RuleProviderInterface;
  */
 class Slugify implements SlugifyInterface
 {
-    const LOWERCASE_NUMBERS_DASHES = '/[^A-Za-z0-9]+/';
+    public const LOWERCASE_NUMBERS_DASHES = '/[^A-Za-z0-9]+/';
 
     /**
      * @var array<string,string>
      */
-    protected $rules = [];
+    protected array $rules = [];
 
     /**
      * @var RuleProviderInterface
      */
-    protected $provider;
+    protected RuleProviderInterface $provider;
 
     /**
      * @var array<string,mixed>
      */
-    protected $options = [
+    protected array $options = [
         'regexp'    => self::LOWERCASE_NUMBERS_DASHES,
         'separator' => '-',
         'lowercase' => true,
@@ -97,7 +97,7 @@ class Slugify implements SlugifyInterface
      *
      * @return string Slugified version of the string
      */
-    public function slugify(string $string, $options = null): string
+    public function slugify(string $string, array|string|null $options = null): string
     {
         // BC: the second argument used to be the separator
         if (is_string($options)) {
@@ -145,7 +145,7 @@ class Slugify implements SlugifyInterface
      *
      * @return Slugify
      */
-    public function addRule($character, $replacement)
+    public function addRule($character, $replacement): self
     {
         $this->rules[$character] = $replacement;
 
@@ -159,7 +159,7 @@ class Slugify implements SlugifyInterface
      *
      * @return Slugify
      */
-    public function addRules(array $rules)
+    public function addRules(array $rules): self
     {
         foreach ($rules as $character => $replacement) {
             $this->addRule($character, $replacement);
@@ -173,7 +173,7 @@ class Slugify implements SlugifyInterface
      *
      * @return Slugify
      */
-    public function activateRuleSet($ruleSet)
+    public function activateRuleSet($ruleSet): self
     {
         return $this->addRules($this->provider->getRules($ruleSet));
     }
@@ -185,7 +185,7 @@ class Slugify implements SlugifyInterface
      *
      * @return Slugify
      */
-    public static function create(array $options = [])
+    public static function create(array $options = []): self
     {
         return new static($options);
     }

--- a/src/SlugifyInterface.php
+++ b/src/SlugifyInterface.php
@@ -32,5 +32,5 @@ interface SlugifyInterface
      *
      * @api
      */
-    public function slugify(string $string, $options = null): string;
+    public function slugify(string $string, array|string|null $options = null): string;
 }


### PR DESCRIPTION
This PR add strong type params and strong typed returns for all the project for enforce best practices in code in PHP 8+ versions.

Also update localheinz/composer-normalize under dev-tools.

Running all tests works perfect.

It should BC for PHP < 8 versions, so maybe a new release minor/mayor should be needed