### PR TITLE
fix-for-new-symfony

### DIFF
--- a/src/Bridge/Symfony/CocurSlugifyExtension.php
+++ b/src/Bridge/Symfony/CocurSlugifyExtension.php
@@ -17,7 +17,7 @@ use Cocur\Slugify\SlugifyInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * CocurSlugifyExtension


### PR DESCRIPTION
Fix deprecation [(issue 338](https://github.com/cocur/slugify/issues/338)):
_The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Cocur\Slugify\Bridge\Symfony\CocurSlugifyExtension"._